### PR TITLE
feat: add Cellframe CELL token (ETH + BSC)

### DIFF
--- a/registry/cellframe/calldata-cell.json
+++ b/registry/cellframe/calldata-cell.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "Cellframe CELL",
+    "contract": {
+      "deployments": [
+        { "chainId": 1,  "address": "0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099" },
+        { "chainId": 56, "address": "0xd98438889Ae7364c7E2A3540547Fad042FB24642" }
+      ]
+    }
+  },
+  "includes": "../../ercs/calldata-erc20-tokens.json",
+  "metadata": {
+    "owner": "Cellframe",
+    "info": {
+      "legalName": "Cellframe Network",
+      "url": "https://cellframe.net/"
+    },
+    "token": {
+      "ticker": "CELL",
+      "name": "Cellframe",
+      "decimals": 18
+    }
+  }
+}


### PR DESCRIPTION
Add ERC-7730 Clear Signing metadata for Cellframe CELL token.

Deployments:
- Ethereum (chainId: 1): 0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099
- BSC (chainId: 56): 0xd98438889Ae7364c7E2A3540547Fad042FB24642

This will enable Clear Signing for CELL token holders using Ledger
devices, resolving EthAppNftNotSupported errors during approve transactions.