### PR TITLE
Add RULL Bridge EIP-712 clear signing metadata

### DIFF
--- a/registry/rull-bridge/eip712-login.json
+++ b/registry/rull-bridge/eip712-login.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "Login": [
+              { "name": "sessionId", "type": "bytes16" },
+              { "name": "nonce", "type": "bytes32" },
+              { "name": "issuedAt", "type": "uint256" },
+              { "name": "expiresAt", "type": "uint256" }
+            ]
+          },
+          "primaryType": "Login"
+        }
+      ],
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }
+      ],
+      "domain": {
+        "name": "RULL.bridge",
+        "version": "1"
+      }
+    }
+  },
+  "metadata": {
+    "owner": "RULL",
+    "info": {
+      "url": "https://rull.com",
+      "name": "RULL Bridge"
+    }
+  },
+  "display": {
+    "formats": {
+      "Login": {
+        "intent": "Sign in to RULL Bridge",
+        "fields": [
+          {
+            "path": "sessionId",
+            "label": "Session",
+            "format": "raw"
+          },
+          {
+            "path": "issuedAt",
+            "label": "Issued at",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "expiresAt",
+            "label": "Expires at",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "required": ["sessionId", "issuedAt", "expiresAt"],
+        "excluded": ["nonce"]
+      }
+    }
+  }
+}

--- a/registry/rull-bridge/eip712-login.json
+++ b/registry/rull-bridge/eip712-login.json
@@ -33,8 +33,8 @@
   "metadata": {
     "owner": "RULL",
     "info": {
-      "url": "https://rull.com",
-      "name": "RULL Bridge"
+      "legalName": "RULL Bridge",
+      "url": "https://rull.com"
     }
   },
   "display": {

--- a/registry/rull-bridge/eip712-vault-commit.json
+++ b/registry/rull-bridge/eip712-vault-commit.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "VaultCommit": [
+              { "name": "vaultId", "type": "bytes16" },
+              { "name": "cipherHash", "type": "bytes32" },
+              { "name": "contentType", "type": "string" },
+              { "name": "size", "type": "uint256" },
+              { "name": "createdAt", "type": "uint256" },
+              { "name": "arweaveTxId", "type": "bytes32" }
+            ]
+          },
+          "primaryType": "VaultCommit"
+        }
+      ],
+      "deployments": [
+        { "chainId": 42161, "address": "0x0000000000000000000000000000000000000000" }
+      ],
+      "domain": {
+        "name": "RULL.justice",
+        "version": "1"
+      }
+    }
+  },
+  "metadata": {
+    "owner": "RULL",
+    "info": {
+      "url": "https://rull.com",
+      "name": "RULL Justice"
+    }
+  },
+  "display": {
+    "formats": {
+      "VaultCommit": {
+        "intent": "Commit data to RULL vault",
+        "fields": [
+          {
+            "path": "vaultId",
+            "label": "Vault",
+            "format": "raw"
+          },
+          {
+            "path": "cipherHash",
+            "label": "Data hash",
+            "format": "raw"
+          },
+          {
+            "path": "contentType",
+            "label": "Content type",
+            "format": "raw"
+          },
+          {
+            "path": "size",
+            "label": "Size (bytes)",
+            "format": "raw"
+          },
+          {
+            "path": "createdAt",
+            "label": "Created at",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "required": ["vaultId", "cipherHash", "contentType", "size", "createdAt"],
+        "excluded": ["arweaveTxId"]
+      }
+    }
+  }
+}

--- a/registry/rull-bridge/eip712-vault-commit.json
+++ b/registry/rull-bridge/eip712-vault-commit.json
@@ -35,8 +35,8 @@
   "metadata": {
     "owner": "RULL",
     "info": {
-      "url": "https://rull.com",
-      "name": "RULL Justice"
+      "legalName": "RULL Justice",
+      "url": "https://rull.com"
     }
   },
   "display": {


### PR DESCRIPTION
## Summary

- Register **Login** and **VaultCommit** EIP-712 message types for clear signing on Ledger devices
- **RULL Bridge** (`Login`): Session authentication via EIP-712 signed message on Ethereum mainnet (chainId 1). Displays session ID, issued/expiry timestamps.
- **RULL Justice** (`VaultCommit`): Encrypted data commitment on Arbitrum (chainId 42161). Displays vault ID, data hash, content type, size, and creation timestamp.

## Context

RULL Bridge is an iOS app that connects directly to Ledger hardware wallets via BLE. Without clear signing metadata, users see a blind signing warning when approving Login and VaultCommit messages. These metadata files enable the Ledger device to display human-readable field names and formatted values.

## Message Types

### Login (RULL Bridge)
| Field | Type | Display |
|-------|------|---------|
| sessionId | bytes16 | Raw hex |
| nonce | bytes32 | Excluded (internal) |
| issuedAt | uint256 | Date/time |
| expiresAt | uint256 | Date/time |

### VaultCommit (RULL Justice)
| Field | Type | Display |
|-------|------|---------|
| vaultId | bytes16 | Raw hex |
| cipherHash | bytes32 | Raw hex |
| contentType | string | Raw |
| size | uint256 | Raw |
| createdAt | uint256 | Date/time |
| arweaveTxId | bytes32 | Excluded (unused) |

## Verification

- Both JSON files validate against the ERC-7730 schema
- All displayed fields are covered in `required`
- Internal/unused fields are in `excluded`