### PR TITLE
feat: add Lagoon vaults ERC-7730 clear signing descriptors

### DIFF
--- a/registry/lagoon/calldata-lagoon-v020-vaults.json
+++ b/registry/lagoon/calldata-lagoon-v020-vaults.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }
+      ],
+      "abi": [
+        {
+          "name": "deposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "mint",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestDeposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "redeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "withdraw",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "setOperator",
+          "type": "function",
+          "inputs": [
+            { "name": "operator", "type": "address" },
+            { "name": "approved", "type": "bool" }
+          ],
+          "stateMutability": "nonpayable",
+          "outputs": [{ "name": "success", "type": "bool" }]
+        },
+        {
+          "name": "claimSharesAndRequestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "sharesToRedeem", "type": "uint256" }
+          ]
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "constants": {
+      "underlyingToken": "0x0000000000000000000000000000000000000000",
+      "underlyingTicker": "TOKEN",
+      "vaultTicker": "VAULT"
+    }
+  },
+  "display": {
+    "formats": {
+      "deposit(uint256 assets, address receiver, address controller)": {
+        "intent": "Claim deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to claim",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "label": "Receive shares",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "mint(uint256 shares, address receiver, address controller)": {
+        "intent": "Mint",
+        "fields": [
+          {
+            "label": "Claim deposit",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "shares",
+            "label": "Shares to mint",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "requestDeposit(uint256 assets, address controller, address owner)": {
+        "intent": "Request deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to deposit",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "controller", "owner"]
+      },
+      "redeem(uint256 shares, address receiver, address controller)": {
+        "intent": "Claim redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "withdraw(uint256 assets, address receiver, address controller)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "label": "Claim withdrawal",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "assets",
+            "label": "Assets to receive",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "requestRedeem(uint256 shares, address controller, address owner)": {
+        "intent": "Request redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "controller", "owner"]
+      },
+      "setOperator(address operator, bool approved)": {
+        "intent": "Set operator",
+        "fields": [
+          {
+            "path": "operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "approved",
+            "label": "Approved",
+            "format": "raw"
+          }
+        ],
+        "required": ["operator", "approved"]
+      },
+      "claimSharesAndRequestRedeem(uint256 sharesToRedeem)": {
+        "intent": "Claim and request redeem",
+        "fields": [
+          {
+            "path": "sharesToRedeem",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          }
+        ],
+        "required": ["sharesToRedeem"]
+      }
+    }
+  }
+}

--- a/registry/lagoon/calldata-lagoon-v050-vaults.json
+++ b/registry/lagoon/calldata-lagoon-v050-vaults.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }
+      ],
+      "abi": [
+        {
+          "name": "deposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "mint",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestDeposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "redeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "withdraw",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "setOperator",
+          "type": "function",
+          "inputs": [
+            { "name": "operator", "type": "address" },
+            { "name": "approved", "type": "bool" }
+          ],
+          "stateMutability": "nonpayable",
+          "outputs": [{ "name": "success", "type": "bool" }]
+        },
+        {
+          "name": "claimSharesAndRequestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "sharesToRedeem", "type": "uint256" }
+          ]
+        },
+        {
+          "name": "syncDeposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "referral", "type": "address" }
+          ]
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "constants": {
+      "underlyingToken": "0x0000000000000000000000000000000000000000",
+      "underlyingTicker": "TOKEN",
+      "vaultTicker": "VAULT"
+    }
+  },
+  "display": {
+    "formats": {
+      "deposit(uint256 assets, address receiver, address controller)": {
+        "intent": "Claim deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to claim",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "label": "Receive shares",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "mint(uint256 shares, address receiver, address controller)": {
+        "intent": "Mint",
+        "fields": [
+          {
+            "label": "Claim deposit",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "shares",
+            "label": "Shares to mint",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "requestDeposit(uint256 assets, address controller, address owner)": {
+        "intent": "Request deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to deposit",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "controller", "owner"]
+      },
+      "redeem(uint256 shares, address receiver, address controller)": {
+        "intent": "Claim redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "withdraw(uint256 assets, address receiver, address controller)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "label": "Claim withdrawal",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "assets",
+            "label": "Assets to receive",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "requestRedeem(uint256 shares, address controller, address owner)": {
+        "intent": "Request redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "controller", "owner"]
+      },
+      "setOperator(address operator, bool approved)": {
+        "intent": "Set operator",
+        "fields": [
+          {
+            "path": "operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "approved",
+            "label": "Approved",
+            "format": "raw"
+          }
+        ],
+        "required": ["operator", "approved"]
+      },
+      "claimSharesAndRequestRedeem(uint256 sharesToRedeem)": {
+        "intent": "Claim and request redeem",
+        "fields": [
+          {
+            "path": "sharesToRedeem",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          }
+        ],
+        "required": ["sharesToRedeem"]
+      },
+      "syncDeposit(uint256 assets, address receiver, address referral)": {
+        "intent": "Deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to deposit",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "label": "Receive shares",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "referral",
+            "label": "Referral",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver"]
+      }
+    }
+  }
+}

--- a/registry/lagoon/calldata-lagoon-v060-vaults.json
+++ b/registry/lagoon/calldata-lagoon-v060-vaults.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }
+      ],
+      "abi": [
+        {
+          "name": "deposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "mint",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestDeposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "redeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "withdraw",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "controller", "type": "address" }
+          ]
+        },
+        {
+          "name": "requestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "controller", "type": "address" },
+            { "name": "owner", "type": "address" }
+          ]
+        },
+        {
+          "name": "setOperator",
+          "type": "function",
+          "inputs": [
+            { "name": "operator", "type": "address" },
+            { "name": "approved", "type": "bool" }
+          ],
+          "stateMutability": "nonpayable",
+          "outputs": [{ "name": "success", "type": "bool" }]
+        },
+        {
+          "name": "claimSharesAndRequestRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "sharesToRedeem", "type": "uint256" }
+          ]
+        },
+        {
+          "name": "syncDeposit",
+          "type": "function",
+          "inputs": [
+            { "name": "assets", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "referral", "type": "address" }
+          ]
+        },
+        {
+          "name": "syncRedeem",
+          "type": "function",
+          "inputs": [
+            { "name": "shares", "type": "uint256" },
+            { "name": "receiver", "type": "address" },
+            { "name": "minimumAssets", "type": "uint256" }
+          ]
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "constants": {
+      "underlyingToken": "0x0000000000000000000000000000000000000000",
+      "underlyingTicker": "TOKEN",
+      "vaultTicker": "VAULT"
+    }
+  },
+  "display": {
+    "formats": {
+      "deposit(uint256 assets, address receiver, address controller)": {
+        "intent": "Claim deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to claim",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "label": "Receive shares",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "mint(uint256 shares, address receiver, address controller)": {
+        "intent": "Mint",
+        "fields": [
+          {
+            "label": "Claim deposit",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "shares",
+            "label": "Shares to mint",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "requestDeposit(uint256 assets, address controller, address owner)": {
+        "intent": "Request deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to deposit",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "controller", "owner"]
+      },
+      "redeem(uint256 shares, address receiver, address controller)": {
+        "intent": "Claim redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "receiver", "controller"]
+      },
+      "withdraw(uint256 assets, address receiver, address controller)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "label": "Claim withdrawal",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "assets",
+            "label": "Assets to receive",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver", "controller"]
+      },
+      "requestRedeem(uint256 shares, address controller, address owner)": {
+        "intent": "Request redemption",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "controller",
+            "label": "Controller",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["shares", "controller", "owner"]
+      },
+      "setOperator(address operator, bool approved)": {
+        "intent": "Set operator",
+        "fields": [
+          {
+            "path": "operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "approved",
+            "label": "Approved",
+            "format": "raw"
+          }
+        ],
+        "required": ["operator", "approved"]
+      },
+      "claimSharesAndRequestRedeem(uint256 sharesToRedeem)": {
+        "intent": "Claim and request redeem",
+        "fields": [
+          {
+            "path": "sharesToRedeem",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          }
+        ],
+        "required": ["sharesToRedeem"]
+      },
+      "syncDeposit(uint256 assets, address receiver, address referral)": {
+        "intent": "Deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Assets to deposit",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          },
+          {
+            "label": "Receive shares",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "referral",
+            "label": "Referral",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          }
+        ],
+        "required": ["assets", "receiver"]
+      },
+      "syncRedeem(uint256 shares, address receiver, uint256 minimumAssets)": {
+        "intent": "Redeem",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "label": "Receive assets",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "minimumAssets",
+            "label": "Min assets out",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" }
+          }
+        ],
+        "required": ["shares", "receiver", "minimumAssets"]
+      }
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-1212-stable.json
+++ b/registry/lagoon/vaults/calldata-lagoon-1212-stable.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "1212 Capital",
+    "info": {
+      "legalName": "1212 Capital",
+      "url": "https://www.1212.capital/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "1212.Stable"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xbb30c3b6046debcbe941281218d18dec8ecebeb5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-722c-u.json
+++ b/registry/lagoon/vaults/calldata-lagoon-722c-u.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "722 Capital",
+    "info": {
+      "legalName": "722 Capital",
+      "url": "https://722.capital/"
+    },
+    "constants": {
+      "underlyingToken": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "722C-U"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 8453,
+          "address": "0xb09f761cb13baca8ec087ac476647361b6314f98"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-9seth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-9seth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "9SETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x07ed467acd4ffd13023046968b0859781cb90d9b"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-9seurc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-9seurc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "underlyingTicker": "EURC",
+      "vaultTicker": "9SEURC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xd0c4c9386f7509c44987f43136be7d4349ccddc9"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-9susdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-9susdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "9SUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-alpusd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-alpusd.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Almanak",
+    "info": {
+      "legalName": "Almanak",
+      "url": "https://almanak.co/"
+    },
+    "constants": {
+      "underlyingToken": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "underlyingTicker": "USDT",
+      "vaultTicker": "alpUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x5a97b0b97197299456af841f8605543b13b12ee3"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-alusd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-alusd.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Almanak",
+    "info": {
+      "legalName": "Almanak",
+      "url": "https://almanak.co/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "alUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xdcd0f5ab30856f28385f641580bbd85f88349124"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dammeth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dammeth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DAMM Capital",
+    "info": {
+      "legalName": "DAMM Capital",
+      "url": "https://dammcap.finance/"
+    },
+    "constants": {
+      "underlyingToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "DAMMeth"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x3c63f3ce75dc83735745cf4e86b63414d95ee355"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dammstable.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dammstable.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DAMM Capital",
+    "info": {
+      "legalName": "DAMM Capital",
+      "url": "https://dammcap.finance/"
+    },
+    "constants": {
+      "underlyingToken": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+      "underlyingTicker": "USDT0",
+      "vaultTicker": "DAMMstable"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dt-applxtz-usdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dt-applxtz-usdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "dt-APPLXTZ-USDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 8453,
+          "address": "0x0a63471da694fc822f5a0a0b65978dda8c8edbe5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dt-morphousdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dt-morphousdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "dt-morphoUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x7d2c2f54792ad72cb834d298f542145b06b703cb"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dtausd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dtausd.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+      "underlyingTicker": "AUSD",
+      "vaultTicker": "dtAUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 143,
+          "address": "0xe95074a86fead8647edff36af2f3f1dd7e8f7adb"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dteth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dteth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0x4200000000000000000000000000000000000006",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "dtETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 8453,
+          "address": "0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dteurc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dteurc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42",
+      "underlyingTicker": "EURC",
+      "vaultTicker": "dtEURC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 8453,
+          "address": "0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-dtusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-dtusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "DeTrade",
+    "info": {
+      "legalName": "DeTrade",
+      "url": "https://detrade.fund/"
+    },
+    "constants": {
+      "underlyingToken": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "DTUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 8453,
+          "address": "0x8092ca384d44260ea4feaf7457b629b8dc6f88f0"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-exusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-exusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Excellion Finance",
+    "info": {
+      "legalName": "Excellion Finance",
+      "url": "https://excellion.finance/"
+    },
+    "constants": {
+      "underlyingToken": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "exUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 43114,
+          "address": "0xb8a14b03900828f863aedd9dd905363863bc31f4"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-gamicuspc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-gamicuspc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "gamicUSPC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xfab0f56c28e3f874b15922b213e696f37b670916"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-gamieth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-gamieth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "gamiETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x2031eceec018549a2c729cacd6c0bfc4be2524ed"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-gamisdusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-gamisdusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "gamisdUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x33e1339567c183fbadcb43f72d11c47229d468ab"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-gamiusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-gamiusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "gamiUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-gamiwbtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-gamiwbtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "underlyingTicker": "WBTC",
+      "vaultTicker": "gamiWBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x414070fb9e64fd69160d75da57e75ba11f9f605a"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-ghemibtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-ghemibtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Gami",
+    "info": {
+      "legalName": "Gami",
+      "url": "https://gamilabs.io/"
+    },
+    "constants": {
+      "underlyingToken": "0x06ea695b91700071b161a434fed42d1dcbad9f00",
+      "underlyingTicker": "hemiBTC",
+      "vaultTicker": "ghemiBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x2a676c2744421b4fae65ce86b47adacb620047d4"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-hubcap-crvusd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-hubcap-crvusd.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "Hub Capital",
+    "constants": {
+      "underlyingToken": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
+      "underlyingTicker": "crvUSD",
+      "vaultTicker": "HubCap-crvUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x9a458370556a68bdc130a80c35b294d0ad947a6a"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-hubcap-usdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-hubcap-usdc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Hub Capital",
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "HubCap-USDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xca790385506b790554571cbc9da73f0130cdcfd5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-lagoonfxsaveyt30oct2025.json
+++ b/registry/lagoon/vaults/calldata-lagoon-lagoonfxsaveyt30oct2025.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x3787c19c32e727310708c0693aec00fb37a01e7b",
+      "underlyingTicker": "YT-fxSAVE-30OCT2025",
+      "vaultTicker": "lagoonfxSAVEYT30OCT2025"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x0d1ea8c0ed10a19b2c714cd7ea923ae4a636ee90"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-moonbtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-moonbtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Odyssey Digital AM",
+    "info": {
+      "legalName": "Odyssey Digital AM",
+      "url": "https://www.odysseydigitalam.com/"
+    },
+    "constants": {
+      "underlyingToken": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "underlyingTicker": "cbBTC",
+      "vaultTicker": "MoonBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x2f945864126c6ba1dcadcb97ad114c9ef94f1379"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-mooneth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-mooneth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Odyssey Digital AM",
+    "info": {
+      "legalName": "Odyssey Digital AM",
+      "url": "https://www.odysseydigitalam.com/"
+    },
+    "constants": {
+      "underlyingToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "MoonETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x08d7eef35f3e317001fe12c19a32f93307b008b4"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-moonusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-moonusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Odyssey Digital AM",
+    "info": {
+      "legalName": "Odyssey Digital AM",
+      "url": "https://www.odysseydigitalam.com/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "MoonUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xa00f63e85b3d242568a9edecb48f5e2cf879b07b"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-mtusd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-mtusd.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0x754704bc059f8c67012fed69bc8a327a5aafb603",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "MTUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 143,
+          "address": "0x0da39b740834090c146dc48357f6a435a1bb33b3"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-pfxsave.json
+++ b/registry/lagoon/vaults/calldata-lagoon-pfxsave.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+      "underlyingTicker": "USDT0",
+      "vaultTicker": "pfxSAVE"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 9745,
+          "address": "0x5f264836ce02496ccf55d7f9aa5cb34e34319db5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-rock-reth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-rock-reth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0xae78736cd615f374d3085123a210448e74fc6393",
+      "underlyingTicker": "rETH",
+      "vaultTicker": "rock.rETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x936facdf10c8c36294e7b9d28345255539d81bc7"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-synusd.json
+++ b/registry/lagoon/vaults/calldata-lagoon-synusd.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Syntropia",
+    "info": {
+      "legalName": "Syntropia",
+      "url": "https://syntropia.ai/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "synUSD"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x1b2cb79a4564206f53ba80b4d780f251b4ae6765"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-synusdplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-synusdplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Syntropia",
+    "info": {
+      "legalName": "Syntropia",
+      "url": "https://syntropia.ai/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "synUSD+"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-synusdx.json
+++ b/registry/lagoon/vaults/calldata-lagoon-synusdx.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Syntropia",
+    "info": {
+      "legalName": "Syntropia",
+      "url": "https://syntropia.ai/"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "synUSDx"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-t9cbbtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-t9cbbtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "underlyingTicker": "cbBTC",
+      "vaultTicker": "T9cbBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xb09f761cb13baca8ec087ac476647361b6314f98"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-tacebtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-tacebtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
+      "underlyingTicker": "eBTC",
+      "vaultTicker": "tacEBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x7388d4b5c4cfc96c9105de913717ba7519178129"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-tacpufeth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-tacpufeth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x37d6382b6889ccef8d6871a8b60e667115eddbcf",
+      "underlyingTicker": "pufETH",
+      "vaultTicker": "tacpufETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 239,
+          "address": "0x85af3c2755f17ba26d7326e8069bf10719441068"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-tacusn.json
+++ b/registry/lagoon/vaults/calldata-lagoon-tacusn.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Noon",
+    "info": {
+      "legalName": "Noon",
+      "url": "https://noon.capital/"
+    },
+    "constants": {
+      "underlyingToken": "0x51a30e647d33a044967fa3dbb04d6ed6f45455f6",
+      "underlyingTicker": "USN",
+      "vaultTicker": "tacUSN"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 239,
+          "address": "0x279385c180f5d01c4a4bdff040f17b8957304762"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-themibtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-themibtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0x06ea695b91700071b161a434fed42d1dcbad9f00",
+      "underlyingTicker": "hemiBTC",
+      "vaultTicker": "tHEMIBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-tulipaethplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-tulipaethplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0xe72b141df173b999ae7c1adcbf60cc9833ce56a8",
+      "underlyingTicker": "ETH+",
+      "vaultTicker": "tulipaETH+"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x9b1c616f5d2d8efb451b2823a58e789dc370705f"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-tulipausdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-tulipausdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "tulipaUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xce0b790ae0d8cf91e01f3fb69025e14569b574f3"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtleavalancheavax.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtleavalancheavax.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+      "underlyingTicker": "WAVAX",
+      "vaultTicker": "turtleAvalancheAVAX"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 43114,
+          "address": "0x662e5efb6b31c5e0a130926dd3c2b78b1678bd08"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtleavalanchebtc-b.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtleavalanchebtc-b.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0x152b9d0fdc40c096757f570a51e494bd4b943e50",
+      "underlyingTicker": "BTC.b",
+      "vaultTicker": "turtleAvalancheBTC.b"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 43114,
+          "address": "0xb893c8d7000e0408eb7d168152ec7fefdd0d25e3"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtleavalancheusdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtleavalancheusdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Tulipa Capital",
+    "info": {
+      "legalName": "Tulipa Capital",
+      "url": "https://tulipa.capital"
+    },
+    "constants": {
+      "underlyingToken": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "turtleAvalancheUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 43114,
+          "address": "0x3048925b3ea5a8c12eecccb8810f5f7544db54af"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlekatanausdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlekatanausdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "turtleKatanaUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xd56031b6e6860bd41dce2729d1bed21c387b26ce"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlekatanausdt.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlekatanausdt.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "underlyingTicker": "USDT",
+      "vaultTicker": "turtleKatanaUSDT"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xe0dfbe4748ed96350754f1328679bd9647bf9621"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlekatanawbtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlekatanawbtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "underlyingTicker": "WBTC",
+      "vaultTicker": "turtleKatanaWBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x423b469268b15821107c38d1e1f702877219bc52"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlekatanaweth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlekatanaweth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "turtleKatanaWETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xbca723c30d55f0915e32019a95aa29ea21fd555c"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlelineaeth.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlelineaeth.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f",
+      "underlyingTicker": "WETH",
+      "vaultTicker": "turtleLineaETH"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 59144,
+          "address": "0x1b316fa2d6c44b65c1ed6d29b37743cd362f0f71"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-turtlelineausdc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-turtlelineausdc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+      "underlyingTicker": "USDC",
+      "vaultTicker": "turtleLineaUSDC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 59144,
+          "address": "0x7df7e45ab573ace8f872b5d5a1689af7ff1a07f7"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-unwbtc.json
+++ b/registry/lagoon/vaults/calldata-lagoon-unwbtc.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "underlyingTicker": "WBTC",
+      "vaultTicker": "unWBTC"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xeff2c1cc0e3bbb6bedc9622a309ed75eab730521"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-ustusrplusplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-ustusrplusplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "underlyingTicker": "USD0++",
+      "vaultTicker": "ustUSR++"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x8092ca384d44260ea4feaf7457b629b8dc6f88f0"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-usyrupplusplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-usyrupplusplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "underlyingTicker": "USD0++",
+      "vaultTicker": "uSYRUP++"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xc5a7884709967a51f67d2daca7451fe3b820e2e9"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-utacplusplus-1.json
+++ b/registry/lagoon/vaults/calldata-lagoon-utacplusplus-1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "underlyingTicker": "USD0++",
+      "vaultTicker": "uTAC++"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xaf87b90e8a3035905697e07bb813d2d59d2b0951"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-utacplusplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-utacplusplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x1791baff6a5e2f2a1340e8b7c1ea2b0c1e2dd1ea",
+      "underlyingTicker": "USD0++",
+      "vaultTicker": "uTAC++"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 239,
+          "address": "0xc218333954e5f6add5f9460396c2181039cce67b"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-uusccplusplus.json
+++ b/registry/lagoon/vaults/calldata-lagoon-uusccplusplus.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v020-vaults.json",
+  "metadata": {
+    "owner": "9Summits",
+    "info": {
+      "legalName": "9Summits",
+      "url": "https://www.9summits.io"
+    },
+    "constants": {
+      "underlyingToken": "0x35d8949372d46b7a3d5a56006ae77b215fc69bc0",
+      "underlyingTicker": "USD0++",
+      "vaultTicker": "uUSCC++"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x8245fd9ae99a482dfe76576dd4298f799c041d61"
+        }
+      ]
+    }
+  }
+}

--- a/registry/lagoon/vaults/calldata-lagoon-yieldusdt.json
+++ b/registry/lagoon/vaults/calldata-lagoon-yieldusdt.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/erc7730-v1.schema.json",
+  "includes": "../calldata-lagoon-v050-vaults.json",
+  "metadata": {
+    "owner": "Everything",
+    "info": {
+      "legalName": "Everything",
+      "url": "https://everything.inc/"
+    },
+    "constants": {
+      "underlyingToken": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "underlyingTicker": "USDT",
+      "vaultTicker": "yieldUSDT"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x01f461a0bbb218bc1943aa027c5bbc424391e541"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds ERC-7730 clear signing descriptors for [Lagoon Finance](https://lagoon.finance/) vaults — an ERC-7540 async vault protocol.

### Structure

- `registry/lagoon/calldata-lagoon-v020-vaults.json` — base descriptor for v0.2.x / v0.4.0 contracts (ERC-7540 + `claimSharesAndRequestRedeem`)
- `registry/lagoon/calldata-lagoon-v050-vaults.json` — base descriptor for v0.5.0 contracts (+ `syncDeposit`)
- `registry/lagoon/calldata-lagoon-v060-vaults.json` — base descriptor for v0.6.0 contracts (+ `syncRedeem`)
- `registry/lagoon/vaults/` — 57 per-vault descriptors, each including the appropriate version base

### Functions covered

All ERC-7540 standard functions (`deposit`, `mint`, `requestDeposit`, `redeem`, `withdraw`, `requestRedeem`, `setOperator`) plus Lagoon-specific extensions (`claimSharesAndRequestRedeem`, `syncDeposit`, `syncRedeem`).

### Chains

Ethereum, Base, Arbitrum, Avalanche, Linea, and others.