### PR TITLE
feat: add Attico rental protocol clear signing descriptors

### DIFF
--- a/registry/attico/calldata-Agreement.json
+++ b/registry/attico/calldata-Agreement.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "Attico Agreement",
+    "contract": {
+      "abi": [
+        { "type": "function", "name": "accept", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
+        { "type": "function", "name": "pay", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
+        { "type": "function", "name": "terminate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
+        {
+          "type": "function", "name": "review",
+          "inputs": [
+            { "name": "rating", "type": "uint8" },
+            { "name": "commentHash", "type": "bytes32" }
+          ],
+          "outputs": [], "stateMutability": "nonpayable"
+        }
+      ],
+      "factory": {
+        "address": "0xa0c8008d8f15fc5b2849af61d0b926c16dd1ac96",
+        "event": "AgreementCreated"
+      }
+    }
+  },
+  "metadata": {
+    "owner": "Attico",
+    "info": {
+      "legalName": "Attico",
+      "url": "https://attico.xyz",
+      "lastUpdate": "2026-04-04T00:00:00Z"
+    }
+  },
+  "display": {
+    "formats": {
+      "accept()": {
+        "intent": "Accept Rental Agreement",
+        "fields": [],
+        "required": []
+      },
+      "pay()": {
+        "intent": "Pay Rent",
+        "fields": [],
+        "required": []
+      },
+      "terminate()": {
+        "intent": "Terminate Agreement Early",
+        "fields": [],
+        "required": []
+      },
+      "review(uint8,bytes32)": {
+        "intent": "Leave Review",
+        "fields": [
+          { "path": "#.rating", "label": "Rating (1-5)", "format": "raw" }
+        ],
+        "required": ["#.rating"],
+        "excluded": ["#.commentHash"]
+      }
+    }
+  }
+}

--- a/registry/attico/calldata-Agreement.json
+++ b/registry/attico/calldata-Agreement.json
@@ -16,10 +16,9 @@
           "outputs": [], "stateMutability": "nonpayable"
         }
       ],
-      "factory": {
-        "address": "0xa0c8008d8f15fc5b2849af61d0b926c16dd1ac96",
-        "event": "AgreementCreated"
-      }
+      "deployments": [
+        { "chainId": 11142220, "address": "0x62877deddd09350f8b571e3bc91342fd062fddf2" }
+      ]
     }
   },
   "metadata": {

--- a/registry/attico/calldata-AgreementFactory.json
+++ b/registry/attico/calldata-AgreementFactory.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "Attico AgreementFactory",
+    "contract": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "createAgreement",
+          "inputs": [
+            { "name": "clientNullifier", "type": "bytes32" },
+            { "name": "token", "type": "address" },
+            { "name": "amount", "type": "uint256" },
+            { "name": "totalPayments", "type": "uint256" },
+            { "name": "paymentInterval", "type": "uint256" },
+            { "name": "propertyHash", "type": "bytes32" }
+          ],
+          "outputs": [{ "name": "agreementId", "type": "uint256" }],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "createAgreementByHandle",
+          "inputs": [
+            { "name": "clientHandle", "type": "string" },
+            { "name": "token", "type": "address" },
+            { "name": "amount", "type": "uint256" },
+            { "name": "totalPayments", "type": "uint256" },
+            { "name": "paymentInterval", "type": "uint256" },
+            { "name": "propertyHash", "type": "bytes32" }
+          ],
+          "outputs": [{ "name": "agreementId", "type": "uint256" }],
+          "stateMutability": "nonpayable"
+        }
+      ],
+      "deployments": [
+        { "chainId": 11142220, "address": "0xa0c8008d8f15fc5b2849af61d0b926c16dd1ac96" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Attico",
+    "info": {
+      "legalName": "Attico",
+      "url": "https://attico.xyz",
+      "lastUpdate": "2026-04-04T00:00:00Z"
+    }
+  },
+  "display": {
+    "formats": {
+      "createAgreement(bytes32,address,uint256,uint256,uint256,bytes32)": {
+        "intent": "Create Rental Agreement",
+        "fields": [
+          { "path": "#.clientNullifier", "label": "Tenant Identity", "format": "raw" },
+          { "path": "#.token", "label": "Payment Token", "format": "addressName", "params": { "types": ["token"], "sources": ["local"] } },
+          { "path": "#.amount", "label": "Rent per Period", "format": "tokenAmount", "params": { "tokenPath": "#.token" } },
+          { "path": "#.totalPayments", "label": "Number of Payments", "format": "raw" },
+          { "path": "#.paymentInterval", "label": "Payment Interval", "format": "duration" }
+        ],
+        "required": ["#.clientNullifier", "#.token", "#.amount", "#.totalPayments", "#.paymentInterval"],
+        "excluded": ["#.propertyHash"]
+      },
+      "createAgreementByHandle(string,address,uint256,uint256,uint256,bytes32)": {
+        "intent": "Create Rental Agreement",
+        "fields": [
+          { "path": "#.clientHandle", "label": "Tenant Handle", "format": "raw" },
+          { "path": "#.token", "label": "Payment Token", "format": "addressName", "params": { "types": ["token"], "sources": ["local"] } },
+          { "path": "#.amount", "label": "Rent per Period", "format": "tokenAmount", "params": { "tokenPath": "#.token" } },
+          { "path": "#.totalPayments", "label": "Number of Payments", "format": "raw" },
+          { "path": "#.paymentInterval", "label": "Payment Interval", "format": "duration" }
+        ],
+        "required": ["#.clientHandle", "#.token", "#.amount", "#.totalPayments", "#.paymentInterval"],
+        "excluded": ["#.propertyHash"]
+      }
+    }
+  }
+}

--- a/registry/attico/tests/calldata-Agreement.tests.json
+++ b/registry/attico/tests/calldata-Agreement.tests.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Pay rent on Agreement #8 (Celo Sepolia)",
+      "rawTx": "0x02f87583aa044c819a850c393e6d00850c393e6d0083048ec194097ec1b8644d7d4d9e2334b8d8c1622fc0f917e580841b9265b8c001a040579eb53df5ad76a52e5f27736a8c16cfc47a79eaa1ff32299f05a37f81d51fa006de724f2dd4099e3c99385aaffafb9082ccdd63036400042f004ccc1b7c5ee7",
+      "txHash": "0xc3cbda59ddf6dab3bae653c3dcc42d45bf56629dc9fad44d83cce58956e82eaa",
+      "expectedTexts": ["Pay Rent"]
+    }
+  ]
+}

--- a/registry/attico/tests/calldata-AgreementFactory.tests.json
+++ b/registry/attico/tests/calldata-AgreementFactory.tests.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "createAgreement on AgreementFactory (Celo Sepolia testnet) — test rawTx to be updated with mainnet deployment",
+      "rawTx": "0x00",
+      "expectedTexts": ["Create Rental Agreement", "Tenant Identity", "Payment Token", "Rent per Period", "Number of Payments", "Payment Interval"]
+    }
+  ]
+}


### PR DESCRIPTION
## Attico — Housing Reputation Protocol

Attico is a housing reputation protocol deployed on **Celo Sepolia** (chainId 11142220) where identity is tied to Self Protocol nullifiers, not wallet addresses. Every rent payment builds a portable, soulbound reputation.

**Website:** https://attico.xyz
**GitHub:** https://github.com/quent043/attico
**Chain:** Celo Sepolia (11142220)

## Descriptors

### `calldata-AgreementFactory.json`
- **`createAgreement(bytes32,address,uint256,uint256,uint256,bytes32)`** — Create a rental agreement with tenant identity, payment token, rent amount, number of payments, and interval
- **`createAgreementByHandle(string,address,uint256,uint256,uint256,bytes32)`** — Same, but referencing tenant by handle

### `calldata-Agreement.json`
Uses **factory context** — Agreement proxies are deployed via EIP-1167 by AgreementFactory.
- **`accept()`** — Tenant accepts the agreement and locks deposit
- **`pay()`** — Tenant pays rent for the current period
- **`terminate()`** — Either party terminates the agreement early
- **`review(uint8,bytes32)`** — Leave a 1-5 star review after agreement completes

## Test files
- `tests/calldata-Agreement.tests.json` — Real `rawTx` from Celo Sepolia pay() transaction
- `tests/calldata-AgreementFactory.tests.json` — Placeholder (testnet deployment)

## Notes
- Protocol is currently deployed on Celo Sepolia testnet for ETHGlobal Prague 2025
- `propertyHash` parameter is excluded from display (internal identifier)
- `commentHash` parameter in review() is excluded (IPFS CID hash, not user-facing)