### PR TITLE
feat: add JAW ERC-7730 schemas (Smart Account, Permissions Manager, UserOperation)

### DIFF
--- a/registry/jaw/calldata-jaw-account.json
+++ b/registry/jaw/calldata-jaw-account.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
+    "context": {
+      "$id": "JAW Smart Account",
+      "contract": {
+        "abi": [
+          {
+            "type": "function",
+            "name": "execute",
+            "inputs": [{ "name": "target", "type": "address" }, { "name": "value", "type": "uint256" }, { "name": "data", "type": "bytes" }],
+            "outputs": [],
+            "stateMutability": "payable"
+          },
+          {
+            "type": "function",
+            "name": "executeBatch",
+            "inputs": [
+              {
+                "name": "calls",
+                "type": "tuple[]",
+                "components": [{ "name": "target", "type": "address" }, { "name": "value", "type": "uint256" }, { "name": "data", "type": "bytes" }]
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "payable"
+          },
+          {
+            "type": "function",
+            "name": "addOwnerAddress",
+            "inputs": [{ "name": "owner", "type": "address" }],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          }
+        ],
+        "deployments": [{ "chainId": 84532, "address": "0xbb4f7d5418Cd8DADB61bb95561179e517572cBCd" }],
+        "factory": {
+          "deployments": [{ "chainId": 84532, "address": "0x5803c076563C85799989d42Fc00292A8aE52fa9E" }],
+          "deployEvent": "event AccountCreated(address indexed account, bytes[] owners)"
+        }
+      }
+    },
+    "metadata": { "owner": "JAW", "info": { "legalName": "JustAName Ltd", "url": "https://jaw.id" } },
+    "display": {
+      "formats": {
+        "execute(address target,uint256 value,bytes data)": {
+          "$id": "execute-single",
+          "intent": "Execute Transaction",
+          "fields": [
+            { "path": "target", "label": "To", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] } },
+            { "path": "value", "label": "Value", "format": "amount" },
+            { "path": "data", "label": "Call", "format": "calldata", "params": { "calleePath": "target" } }
+          ],
+          "required": ["target", "value", "data"],
+          "excluded": ["data.[]"]
+        },
+        "executeBatch((address target,uint256 value,bytes data)[] calls)": {
+          "$id": "execute-batch",
+          "intent": "Execute Batch",
+          "fields": [
+            {
+              "path": "calls.[]",
+              "fields": [
+                { "path": "target", "label": "To", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] } },
+                { "path": "value", "label": "Value", "format": "amount" },
+                { "path": "data", "label": "Call", "format": "calldata", "params": { "calleePath": "target" } }
+              ]
+            }
+          ],
+          "required": ["calls"],
+          "excluded": ["calls.[].data.[]"]
+        },
+        "addOwnerAddress(address owner)": {
+          "$id": "add-owner",
+          "intent": "Add Account Owner",
+          "fields": [{ "path": "owner", "label": "New owner", "format": "addressName", "params": { "types": ["wallet", "eoa"] } }],
+          "required": ["owner"],
+          "excluded": []
+        }
+      }
+    }
+  }

--- a/registry/jaw/calldata-jaw-permissions-manager.json
+++ b/registry/jaw/calldata-jaw-permissions-manager.json
@@ -1,0 +1,192 @@
+{
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
+    "context": {
+      "$id": "JAW Permissions Manager",
+      "contract": {
+        "abi": [
+          {
+            "type": "function",
+            "name": "approve",
+            "inputs": [
+              {
+                "name": "permission",
+                "type": "tuple",
+                "components": [
+                  { "name": "account", "type": "address" },
+                  { "name": "spender", "type": "address" },
+                  { "name": "start", "type": "uint48" },
+                  { "name": "end", "type": "uint48" },
+                  { "name": "salt", "type": "uint256" },
+                  {
+                    "name": "calls",
+                    "type": "tuple[]",
+                    "components": [{ "name": "target", "type": "address" }, { "name": "selector", "type": "bytes4" }, { "name": "checker", "type": "address" }]
+                  },
+                  {
+                    "name": "spends",
+                    "type": "tuple[]",
+                    "components": [
+                      { "name": "token", "type": "address" },
+                      { "name": "allowance", "type": "uint160" },
+                      { "name": "unit", "type": "uint8" },
+                      { "name": "multiplier", "type": "uint16" }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "outputs": [{ "name": "", "type": "bool" }],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "revoke",
+            "inputs": [
+              {
+                "name": "permission",
+                "type": "tuple",
+                "components": [
+                  { "name": "account", "type": "address" },
+                  { "name": "spender", "type": "address" },
+                  { "name": "start", "type": "uint48" },
+                  { "name": "end", "type": "uint48" },
+                  { "name": "salt", "type": "uint256" },
+                  {
+                    "name": "calls",
+                    "type": "tuple[]",
+                    "components": [{ "name": "target", "type": "address" }, { "name": "selector", "type": "bytes4" }, { "name": "checker", "type": "address" }]
+                  },
+                  {
+                    "name": "spends",
+                    "type": "tuple[]",
+                    "components": [
+                      { "name": "token", "type": "address" },
+                      { "name": "allowance", "type": "uint160" },
+                      { "name": "unit", "type": "uint8" },
+                      { "name": "multiplier", "type": "uint16" }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "executeBatch",
+            "inputs": [
+              {
+                "name": "permission",
+                "type": "tuple",
+                "components": [
+                  { "name": "account", "type": "address" },
+                  { "name": "spender", "type": "address" },
+                  { "name": "start", "type": "uint48" },
+                  { "name": "end", "type": "uint48" },
+                  { "name": "salt", "type": "uint256" },
+                  {
+                    "name": "calls",
+                    "type": "tuple[]",
+                    "components": [{ "name": "target", "type": "address" }, { "name": "selector", "type": "bytes4" }, { "name": "checker", "type": "address" }]
+                  },
+                  {
+                    "name": "spends",
+                    "type": "tuple[]",
+                    "components": [
+                      { "name": "token", "type": "address" },
+                      { "name": "allowance", "type": "uint160" },
+                      { "name": "unit", "type": "uint8" },
+                      { "name": "multiplier", "type": "uint16" }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "calls",
+                "type": "tuple[]",
+                "components": [{ "name": "target", "type": "address" }, { "name": "value", "type": "uint256" }, { "name": "data", "type": "bytes" }]
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          }
+        ],
+        "deployments": [{ "chainId": 84532, "address": "0xf1b40E3D5701C04d86F7828f0EB367B9C90901D8" }]
+      }
+    },
+    "metadata": {
+      "owner": "JAW",
+      "info": { "legalName": "JustAName Ltd", "url": "https://jaw.id" },
+      "enums": { "spendPeriod": { "0": "Per Minute", "1": "Per Hour", "2": "Per Day", "3": "Per Week", "4": "Per Month", "5": "Forever" } },
+      "constants": { "nativeToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", "noChecker": "0x0000000000000000000000000000000000000000" }
+    },
+    "display": {
+      "formats": {
+        "approve((address account,address spender,uint48 start,uint48 end,uint256 salt,(address target,bytes4 selector,address checker)[] calls,(address token,uint160 allowance,uint8 unit,uint16 multiplier)[] spends) permission)": {
+          "$id": "grant-permission",
+          "intent": "Grant Permission to Agent",
+          "fields": [
+            { "path": "permission.account", "label": "Account", "format": "addressName", "params": { "types": ["wallet", "contract"] } },
+            { "path": "permission.spender", "label": "Agent", "format": "addressName", "params": { "types": ["wallet", "eoa"] } },
+            { "path": "permission.start", "label": "Valid from", "format": "date", "params": { "encoding": "timestamp" } },
+            { "path": "permission.end", "label": "Expires", "format": "date", "params": { "encoding": "timestamp" } },
+            {
+              "path": "permission.calls.[]",
+              "fields": [
+                { "path": "target", "label": "Allowed contract", "format": "addressName", "params": { "types": ["contract"] } },
+                { "path": "selector", "label": "Function selector", "format": "raw" }
+              ]
+            },
+            {
+              "path": "permission.spends.[]",
+              "fields": [
+                { "path": "token", "label": "Token", "format": "addressName", "params": { "types": ["token"] } },
+                { "path": "allowance", "label": "Spending limit", "format": "tokenAmount", "params": { "tokenPath": "token" } },
+                { "path": "unit", "label": "Spending period", "format": "enum", "params": { "$ref": "$.metadata.enums.spendPeriod" } },
+                { "path": "multiplier", "label": "Period multiplier", "format": "raw" }
+              ]
+            }
+          ],
+          "required": [
+            "permission.account",
+            "permission.spender",
+            "permission.start",
+            "permission.end",
+            "permission.calls",
+            "permission.spends"
+          ],
+          "excluded": ["permission.salt", "permission.calls.[].checker"]
+        },
+        "revoke((address account,address spender,uint48 start,uint48 end,uint256 salt,(address target,bytes4 selector,address checker)[] calls,(address token,uint160 allowance,uint8 unit,uint16 multiplier)[] spends) permission)": {
+          "$id": "revoke-permission",
+          "intent": "Revoke Agent Permission",
+          "fields": [
+            { "path": "permission.account", "label": "Account", "format": "addressName", "params": { "types": ["wallet", "contract"] } },
+            { "path": "permission.spender", "label": "Agent", "format": "addressName", "params": { "types": ["wallet", "eoa"] } }
+          ],
+          "required": ["permission.account", "permission.spender"],
+          "excluded": ["permission.salt", "permission.start", "permission.end", "permission.calls", "permission.spends"]
+        },
+        "executeBatch((address account,address spender,uint48 start,uint48 end,uint256 salt,(address target,bytes4 selector,address checker)[] calls,(address token,uint160 allowance,uint8 unit,uint16 multiplier)[] spends) permission,(address target,uint256 value,bytes data)[] calls)": {
+          "$id": "execute-with-permission",
+          "intent": "Execute with Permission",
+          "fields": [
+            { "path": "permission.account", "label": "Account", "format": "addressName", "params": { "types": ["wallet", "contract"] } },
+            { "path": "permission.spender", "label": "Agent", "format": "addressName", "params": { "types": ["wallet", "eoa"] } },
+            { "path": "permission.end", "label": "Permission expires", "format": "date", "params": { "encoding": "timestamp" } },
+            {
+              "path": "calls.[]",
+              "fields": [
+                { "path": "target", "label": "To", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] } },
+                { "path": "value", "label": "Value", "format": "amount" },
+                { "path": "data", "label": "Call", "format": "calldata", "params": { "calleePath": "target" } }
+              ]
+            }
+          ],
+          "required": ["permission.account", "permission.spender", "calls"],
+          "excluded": ["permission.salt", "permission.start", "permission.calls", "permission.spends", "calls.[].data.[]"]
+        }
+      }
+    }
+  }

--- a/registry/jaw/eip712-jaw-useroperation.json
+++ b/registry/jaw/eip712-jaw-useroperation.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
+    "context": {
+      "eip712": {
+        "deployments": [{ "chainId": 84532, "address": "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108" }],
+        "domain": { "name": "ERC4337", "version": "1" },
+        "schemas": [
+          {
+            "primaryType": "PackedUserOperation",
+            "types": {
+              "EIP712Domain": [
+                { "name": "name", "type": "string" },
+                { "name": "version", "type": "string" },
+                { "name": "chainId", "type": "uint256" },
+                { "name": "verifyingContract", "type": "address" }
+              ],
+              "PackedUserOperation": [
+                { "name": "sender", "type": "address" },
+                { "name": "nonce", "type": "uint256" },
+                { "name": "initCode", "type": "bytes" },
+                { "name": "callData", "type": "bytes" },
+                { "name": "accountGasLimits", "type": "bytes32" },
+                { "name": "preVerificationGas", "type": "uint256" },
+                { "name": "gasFees", "type": "bytes32" },
+                { "name": "paymasterAndData", "type": "bytes" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "metadata": { "owner": "JAW" },
+    "display": {
+      "formats": {
+        "PackedUserOperation": {
+          "$id": "packed-user-operation",
+          "intent": "Sign UserOperation",
+          "fields": [
+            { "path": "sender", "label": "Smart Account", "format": "addressName", "params": { "types": ["wallet", "contract"] } },
+            { "path": "callData", "label": "Operation", "format": "calldata", "params": { "calleePath": "sender" } }
+          ],
+          "required": ["sender", "callData"],
+          "excluded": ["nonce", "initCode", "accountGasLimits", "preVerificationGas", "gasFees", "paymasterAndData", "callData.[]"]
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## Description

This change adds three [ERC-7730](https://eips.ethereum.org/EIPS/eip-7730) registry payloads under `registry/jaw/` so wallets can show human-readable signing for [JAW](jaw.id) contracts on **Base Sepolia (chain ID 84532)** built at ETHGlobal Cannes 2026

### What was added

1. **`calldata-jaw-account.json`** — JAW Smart Account calldata descriptions for `execute`, `executeBatch`, and `addOwnerAddress`, including deployment and factory metadata (`AccountCreated`).

2. **`calldata-jaw-permissions-manager.json`** — Permissions Manager calldata for `approve`, `revoke`, and `executeBatch`, with structured fields for permission tuples (allowed calls, spending limits), `spendPeriod` enums, and constants for native token / no-checker.

3. **`eip712-jaw-useroperation.json`** — EIP-712 typed data for ERC-4337 `PackedUserOperation` (domain `ERC4337` v1), focused on clear display of `sender` and decoded `callData`.

### Why

Improves **clear signing** for JAW smart accounts, delegated permissions, and bundled UserOperations so users see intents and fields instead of opaque hex.

**Commit:** `db0dc3d` — *feat: add JAW Smart Account, Permissions Manager, and UserOperation schemas*

---