### PR TITLE
feat: Add Hoodlums NFT clear signing metadata (ApeChain 33139)

### DIFF
--- a/registry/hoodlums/calldata-HoodToken.json
+++ b/registry/hoodlums/calldata-HoodToken.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "HoodToken",
+    "contract": {
+      "deployments": [
+        { "chainId": 33139, "address": "0xbbc7c3aff30f79e4dbcea65f368947809647f3a2" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Hoodlums",
+    "info": { "url": "https://hoodlumsnft.io" },
+    "contractName": "HoodToken",
+    "token": { "name": "HOOD", "ticker": "HOOD", "decimals": 18 }
+  },
+  "display": {
+    "formats": {
+      "approve(address spender, uint256 amount)": {
+        "$id": "approve",
+        "intent": "Approve HOOD Token Spending",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Approved Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "amount",
+            "label": "Amount Approved",
+            "format": "tokenAmount",
+            "params": { "token": "0xbbc7c3aff30f79e4dbcea65f368947809647f3a2" },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/hoodlums/calldata-HoodlumsRafflesV2.json
+++ b/registry/hoodlums/calldata-HoodlumsRafflesV2.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "HoodlumsRafflesV2",
+    "contract": {
+      "deployments": [
+        { "chainId": 33139, "address": "0x2648e2f2420ba6ce38e79e28196a12755ef629d5" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Hoodlums",
+    "info": { "url": "https://hoodlumsnft.io" },
+    "contractName": "HoodlumsRafflesV2"
+  },
+  "display": {
+    "formats": {
+      "buyEntry(uint256 raffleId, uint256[] nftIds)": {
+        "$id": "buyEntry",
+        "intent": "Enter Hoodlums Raffle",
+        "fields": [
+          { "path": "raffleId", "label": "Raffle ID", "format": "raw", "visible": "always" },
+          { "path": "nftIds.[]", "label": "Hoodlum Token ID", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/hoodlums/calldata-HoodlumsStaking.json
+++ b/registry/hoodlums/calldata-HoodlumsStaking.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "HoodlumsStaking",
+    "contract": {
+      "deployments": [
+        { "chainId": 33139, "address": "0x98b53700f450428f627a10c9e2bbc96b1e963f47" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Hoodlums",
+    "info": { "url": "https://hoodlumsnft.io" },
+    "contractName": "HoodlumsStaking"
+  },
+  "display": {
+    "formats": {
+      "deploy(uint256 poolId, uint256[] tokenIds)": {
+        "$id": "deploy",
+        "intent": "Stake Hoodlums",
+        "fields": [
+          { "path": "poolId", "label": "Staking Pool", "format": "raw", "visible": "always" },
+          { "path": "tokenIds.[]", "label": "Hoodlum Token ID", "format": "raw", "visible": "always" }
+        ]
+      },
+      "recall(uint256 deploymentId)": {
+        "$id": "recall",
+        "intent": "Recall Staked Hoodlums",
+        "fields": [
+          { "path": "deploymentId", "label": "Deployment ID", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds ERC-7730 clear signing descriptors for [Hoodlums NFT](https://hoodlumsnft.io), a project on **ApeChain (chainId 33139)**.

Currently Ledger users cannot interact with our dapp (staking, raffles) without enabling blind signing because ApeChain is not natively listed. This submission provides clear, human-readable transaction details for all user-facing contract calls.

## Contracts

| File | Contract | Address | Functions |
|------|----------|---------|-----------|
| `calldata-HoodlumsStaking.json` | HoodlumsStaking | `0x98b53700f450428f627a10c9e2bbc96b1e963f47` | `deploy`, `recall` |
| `calldata-HoodlumsRafflesV2.json` | HoodlumsRafflesV2 | `0x2648e2f2420ba6ce38e79e28196a12755ef629d5` | `buyEntry` |
| `calldata-HoodToken.json` | HoodToken (ERC-20) | `0xbbc7c3aff30f79e4dbcea65f368947809647f3a2` | `approve` |

All on ApeChain (chainId 33139).

## What each transaction does

- **`deploy(uint256 poolId, uint256[] tokenIds)`** — Stakes one or more Hoodlums NFTs into a time-locked reward pool. NFTs remain in the user's wallet (non-custodial).
- **`recall(uint256 deploymentId)`** — Returns staked NFTs and distributes HOOD token rewards when the lock period is complete.
- **`buyEntry(uint256 raffleId, uint256[] nftIds)`** — Uses Hoodlums NFTs as tickets to enter an onchain raffle. NFTs remain in the user's wallet.
- **`approve(address spender, uint256 amount)`** — Standard ERC-20 approval for HOOD token spending.

## Checklist

- [x] Files follow the `calldata-<ContractName>.json` naming convention
- [x] `$schema` points to `../../specs/erc7730-v2.schema.json`
- [x] All addresses are lowercase
- [x] `visible: "always"` set on all user-critical fields
- [x] Function signatures include parameter names
- [x] I am authorised to submit on behalf of the Hoodlums project

## Project

- Website: https://hoodlumsnft.io
- Chain: ApeChain (33139)