### PR TITLE
feat: upgrade contract addresses for Okx Dexrouter V1.0.8-suffix-compat

### DIFF
--- a/registry/okx/calldata-OkxDexRouterV1.0.8-suffix-compat.json
+++ b/registry/okx/calldata-OkxDexRouterV1.0.8-suffix-compat.json
@@ -2,7 +2,7 @@
   "$schema": "../../specs/erc7730-v2.schema.json",
   "metadata": {
     "owner": "OKX Labs",
-    "info": { "url": "https://web3.okx.com/dex-swap", "deploymentDate": "2026-03-20T03:24:35Z" },
+    "info": { "url": "https://web3.okx.com/dex-swap", "deploymentDate": "2026-05-07T03:25:22Z" },
     "enums": { "swapDirection": { "0": "ETH --> WETH", "1": "WETH --> ETH", "128": "WETH --> ETH" } },
     "contractName": "OKX DEX Router v1.0.8-suffix-compat"
   },
@@ -19,12 +19,13 @@
         { "chainId": 143, "address": "0x7A7AD9aa93cd0A2D0255326E5Fb145CEc14997FF" },
         { "chainId": 146, "address": "0x79f7C6C6dc16Ed3154E85A8ef9c1Ef31CEFaEB19" },
         { "chainId": 169, "address": "0x69C236E021F5775B0D0328ded5EaC708E3B869DF" },
-        { "chainId": 196, "address": "0xbec6d0E341102732e4FD62EC50E2F0a9D1bd1D33" },
+        { "chainId": 196, "address": "0x722db4f285F8bD91ef7AF6DA397e83f7fA4E80a7" },
         { "chainId": 250, "address": "0x25e7f77F33206d311A0130D4b5B881E5Db1181b1" },
         { "chainId": 324, "address": "0x6f7c20464258c732577c87a9B467619e03e5C158" },
         { "chainId": 1030, "address": "0x95418635f012fFd10eAFcDaF4137e90371f06917" },
         { "chainId": 1088, "address": "0x25e7f77F33206d311A0130D4b5B881E5Db1181b1" },
         { "chainId": 1101, "address": "0x6f7c20464258c732577c87a9B467619e03e5C158" },
+        { "chainId": 1672, "address": "0x75f21a97bd89a9a5683a9f46b5d5b4a080708dea" },
         { "chainId": 4200, "address": "0x6f7c20464258c732577c87a9B467619e03e5C158" },
         { "chainId": 5000, "address": "0xcF76984119C7f6ae56fAfE680d39C08278b7eCF4" },
         { "chainId": 7000, "address": "0xF5402CCC5fC3181B45D7571512999D3Eea0257B6" },
@@ -33,7 +34,7 @@
         { "chainId": 42161, "address": "0x7CF6b330b437E9fb432B1400DE17B03357Cf049A" },
         { "chainId": 43114, "address": "0xa94Fcf9fc56a864f8DE51e6315aee5863AD63C91" },
         { "chainId": 59144, "address": "0x2E1Dee213BA8d7af0934C49a23187BabEACa8764" },
-        { "chainId": 81457, "address": "0xcF76984119C7f6ae56fAfE680d39C08278b7eCF4" },
+        { "chainId": 81457, "address": "0x6F91349e4161068c1cA6BAAce1570621bb00FDeb" },
         { "chainId": 534352, "address": "0x5e2F47bD7D4B357fCfd0Bb224Eb665773B1B9801" }
       ]
     }


### PR DESCRIPTION
Updated contract addresses for the new V1.0.8-suffix-compat deployment across 26 chains.