### PR TITLE
Add Porto Orchestrator Intent clear signing metadata

### DIFF
--- a/registry/porto/eip712-Orchestrator-0.5.5.json
+++ b/registry/porto/eip712-Orchestrator-0.5.5.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "Porto Orchestrator 0.5.5",
+    "eip712": {
+      "domain": { "name": "Orchestrator", "version": "0.5.5" },
+      "deployments": [
+        { "chainId": 1, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 10, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 56, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 4663, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 8453, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 42161, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 84532, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 11155111, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" },
+        { "chainId": 11155420, "address": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF" }
+      ]
+    }
+  },
+  "metadata": { "owner": "Porto", "contractName": "Orchestrator", "info": { "url": "https://porto.sh" } },
+  "display": {
+    "formats": {
+      "Intent(bool multichain,address eoa,Call[] calls,uint256 nonce,address payer,address paymentToken,uint256 paymentMaxAmount,uint256 combinedGas,bytes[] encodedPreCalls,bytes[] encodedFundTransfers,address settler,uint256 expiry)Call(address to,uint256 value,bytes data)": {
+        "$id": "Porto Intent",
+        "intent": "Execute account actions",
+        "fields": [
+          { "path": "multichain", "label": "Multiple networks", "format": "raw", "visible": "always" },
+          {
+            "path": "eoa",
+            "label": "Account",
+            "format": "addressName",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "calls.[]",
+            "label": "Account action",
+            "fields": [
+              {
+                "path": "to",
+                "label": "Target",
+                "format": "addressName",
+                "params": { "types": ["contract", "eoa"], "sources": ["local", "ens"] },
+                "visible": "always"
+              },
+              { "path": "value", "label": "Native value", "format": "raw", "visible": "always" },
+              {
+                "path": "data",
+                "label": "Call",
+                "format": "calldata",
+                "params": { "calleePath": "to", "amountPath": "value", "spenderPath": "#.eoa" },
+                "visible": "always"
+              }
+            ]
+          },
+          {
+            "path": "paymentMaxAmount",
+            "label": "Maximum payment",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "paymentToken", "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000" },
+            "visible": "always"
+          },
+          { "path": "paymentToken", "label": "Payment token", "format": "raw", "visible": "always" },
+          { "path": "payer", "label": "Payer", "format": "raw", "visible": "always" },
+          { "path": "combinedGas", "label": "Combined gas limit", "format": "raw", "visible": "always" },
+          { "path": "encodedPreCalls.[]", "label": "Pre-call", "format": "raw", "visible": "always" },
+          { "path": "encodedFundTransfers.[]", "label": "Fund transfer", "format": "raw", "visible": "always" },
+          { "path": "settler", "label": "Settler", "format": "raw", "visible": "always" },
+          { "path": "expiry", "label": "Expiry", "format": "raw", "visible": "always" },
+          { "path": "nonce", "label": "Nonce", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/porto/testsv2/eip712-Orchestrator-0.5.5.tests.json
+++ b/registry/porto/testsv2/eip712-Orchestrator-0.5.5.tests.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../eip712-Orchestrator-0.5.5.json",
+  "dataProvider": {
+    "tokens": {
+      "0x0000000000000000000000000000000000000000": {
+        "symbol": "ETH",
+        "decimals": 18,
+        "name": "Ether"
+      },
+      "0xaf88d065e77c8cc2239327c5edb3a432268e5831": {
+        "symbol": "USDC",
+        "decimals": 6,
+        "name": "USD Coin"
+      },
+      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
+        "symbol": "USDC",
+        "decimals": 6,
+        "name": "USD Coin"
+      },
+      "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": {
+        "symbol": "USDC",
+        "decimals": 6,
+        "name": "USD Coin"
+      }
+    },
+    "addressNames": {
+      "0x2222222222222222222222222222222222222222": "Cloaked account",
+      "0x4444444444444444444444444444444444444444": "Example target"
+    }
+  },
+  "tests": [
+    {
+      "description": "Prepare a Cloaked account on Arbitrum with a USDC fee",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Intent": [
+            { "name": "multichain", "type": "bool" },
+            { "name": "eoa", "type": "address" },
+            { "name": "calls", "type": "Call[]" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "payer", "type": "address" },
+            { "name": "paymentToken", "type": "address" },
+            { "name": "paymentMaxAmount", "type": "uint256" },
+            { "name": "combinedGas", "type": "uint256" },
+            { "name": "encodedPreCalls", "type": "bytes[]" },
+            { "name": "encodedFundTransfers", "type": "bytes[]" },
+            { "name": "settler", "type": "address" },
+            { "name": "expiry", "type": "uint256" }
+          ],
+          "Call": [
+            { "name": "to", "type": "address" },
+            { "name": "value", "type": "uint256" },
+            { "name": "data", "type": "bytes" }
+          ]
+        },
+        "primaryType": "Intent",
+        "domain": {
+          "name": "Orchestrator",
+          "version": "0.5.5",
+          "chainId": 42161,
+          "verifyingContract": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF"
+        },
+        "message": {
+          "multichain": false,
+          "eoa": "0x2222222222222222222222222222222222222222",
+          "calls": [],
+          "nonce": "0",
+          "payer": "0x0000000000000000000000000000000000000000",
+          "paymentToken": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "paymentMaxAmount": "125000",
+          "combinedGas": "250000",
+          "encodedPreCalls": [],
+          "encodedFundTransfers": [],
+          "settler": "0x0000000000000000000000000000000000000000",
+          "expiry": "0"
+        }
+      },
+      "expected": {
+        "intent": "Execute account actions",
+        "owner": "Porto",
+        "fields": [
+          { "label": "Multiple networks", "value": "false" },
+          { "label": "Account", "value": "Cloaked account" },
+          { "label": "Maximum payment", "value": "0.125 USDC" },
+          { "label": "Payment token", "value": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" },
+          { "label": "Payer", "value": "0x0000000000000000000000000000000000000000" },
+          { "label": "Combined gas limit", "value": "250000" },
+          { "label": "Settler", "value": "0x0000000000000000000000000000000000000000" },
+          { "label": "Expiry", "value": "0" },
+          { "label": "Nonce", "value": "0" }
+        ]
+      }
+    },
+    {
+      "description": "Display one Porto account action and a USDC fee",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Intent": [
+            { "name": "multichain", "type": "bool" },
+            { "name": "eoa", "type": "address" },
+            { "name": "calls", "type": "Call[]" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "payer", "type": "address" },
+            { "name": "paymentToken", "type": "address" },
+            { "name": "paymentMaxAmount", "type": "uint256" },
+            { "name": "combinedGas", "type": "uint256" },
+            { "name": "encodedPreCalls", "type": "bytes[]" },
+            { "name": "encodedFundTransfers", "type": "bytes[]" },
+            { "name": "settler", "type": "address" },
+            { "name": "expiry", "type": "uint256" }
+          ],
+          "Call": [
+            { "name": "to", "type": "address" },
+            { "name": "value", "type": "uint256" },
+            { "name": "data", "type": "bytes" }
+          ]
+        },
+        "primaryType": "Intent",
+        "domain": {
+          "name": "Orchestrator",
+          "version": "0.5.5",
+          "chainId": 1,
+          "verifyingContract": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF"
+        },
+        "message": {
+          "multichain": false,
+          "eoa": "0x2222222222222222222222222222222222222222",
+          "calls": [
+            {
+              "to": "0x4444444444444444444444444444444444444444",
+              "value": "500000000000000000",
+              "data": "0x12345678"
+            }
+          ],
+          "nonce": "7",
+          "payer": "0x0000000000000000000000000000000000000000",
+          "paymentToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "paymentMaxAmount": "3000",
+          "combinedGas": "180000",
+          "encodedPreCalls": [],
+          "encodedFundTransfers": [],
+          "settler": "0x0000000000000000000000000000000000000000",
+          "expiry": "0"
+        }
+      },
+      "expected": {
+        "intent": "Execute account actions",
+        "owner": "Porto",
+        "fields": [
+          { "label": "Multiple networks", "value": "false" },
+          { "label": "Account", "value": "Cloaked account" },
+          { "label": "Target", "value": "Example target" },
+          { "label": "Native value", "value": "500000000000000000" },
+          { "label": "Call", "value": "0x12345678" },
+          { "label": "Maximum payment", "value": "0.003 USDC" },
+          { "label": "Payment token", "value": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+          { "label": "Payer", "value": "0x0000000000000000000000000000000000000000" },
+          { "label": "Combined gas limit", "value": "180000" },
+          { "label": "Settler", "value": "0x0000000000000000000000000000000000000000" },
+          { "label": "Expiry", "value": "0" },
+          { "label": "Nonce", "value": "7" }
+        ]
+      }
+    },
+    {
+      "description": "Display signed pre-calls, fund transfers, settlement, and expiry",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Intent": [
+            { "name": "multichain", "type": "bool" },
+            { "name": "eoa", "type": "address" },
+            { "name": "calls", "type": "Call[]" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "payer", "type": "address" },
+            { "name": "paymentToken", "type": "address" },
+            { "name": "paymentMaxAmount", "type": "uint256" },
+            { "name": "combinedGas", "type": "uint256" },
+            { "name": "encodedPreCalls", "type": "bytes[]" },
+            { "name": "encodedFundTransfers", "type": "bytes[]" },
+            { "name": "settler", "type": "address" },
+            { "name": "expiry", "type": "uint256" }
+          ],
+          "Call": [
+            { "name": "to", "type": "address" },
+            { "name": "value", "type": "uint256" },
+            { "name": "data", "type": "bytes" }
+          ]
+        },
+        "primaryType": "Intent",
+        "domain": {
+          "name": "Orchestrator",
+          "version": "0.5.5",
+          "chainId": 8453,
+          "verifyingContract": "0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF"
+        },
+        "message": {
+          "multichain": false,
+          "eoa": "0x2222222222222222222222222222222222222222",
+          "calls": [],
+          "nonce": "12",
+          "payer": "0x1111111111111111111111111111111111111111",
+          "paymentToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "paymentMaxAmount": "0",
+          "combinedGas": "500000",
+          "encodedPreCalls": ["0x010203"],
+          "encodedFundTransfers": ["0x040506"],
+          "settler": "0x3333333333333333333333333333333333333333",
+          "expiry": "1893456000"
+        }
+      },
+      "expected": {
+        "intent": "Execute account actions",
+        "owner": "Porto",
+        "fields": [
+          { "label": "Multiple networks", "value": "false" },
+          { "label": "Account", "value": "Cloaked account" },
+          { "label": "Maximum payment", "value": "0 USDC" },
+          { "label": "Payment token", "value": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" },
+          { "label": "Payer", "value": "0x1111111111111111111111111111111111111111" },
+          { "label": "Combined gas limit", "value": "500000" },
+          { "label": "Pre-call", "value": "0x010203" },
+          { "label": "Fund transfer", "value": "0x040506" },
+          { "label": "Settler", "value": "0x3333333333333333333333333333333333333333" },
+          { "label": "Expiry", "value": "1893456000" },
+          { "label": "Nonce", "value": "12" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an ERC-7730 v2 descriptor for the Porto `Orchestrator` `Intent` EIP-712 message, plus three offline fixtures covering:

- an empty-call account setup intent
- a regular account call
- non-empty pre-calls, fund transfers, settlement, and expiry

Only `registry/porto/` is changed.

## Version and deployment provenance

- Cloaked's production lockfile resolves the signing implementation to `viem@2.40.3`, and its signing code uses the exact EIP-712 domain `Orchestrator` / `0.5.5`.
- The deployed account suite is the [`v0.5.7` release](https://github.com/ithacaxyz/account/tree/v0.5.7). The release version and EIP-712 domain version are intentionally different: the release contains the `Orchestrator` `0.5.5` domain and type definition in [`src/Orchestrator.sol`](https://github.com/ithacaxyz/account/blob/v0.5.7/src/Orchestrator.sol).
- Release tag `v0.5.7` resolves to commit `7997f6ab22dc0076be4e0ee7a6cbd4cb7e12b591`.
- All listed deployments use `0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF`. I queried `eip712Domain()` on each listed chain and confirmed the domain name, version, chain ID, and verifying contract.
- The deployed `INTENT_TYPEHASH()` is `0x32ea001e8ffe499807c3f32d34d7e040163b7744091bec80a98c54abd3841386`, matching the descriptor's complete type string and the tagged Solidity source.

The covered chain IDs are Ethereum (1), Optimism (10), BNB Smart Chain (56), New Chain (4663), Base (8453), Arbitrum One (42161), Base Sepolia (84532), Sepolia (11155111), and OP Sepolia (11155420).

## Security choices

- The descriptor is bound to both the domain and explicit `(chainId, address)` deployments. It does not rely on the domain name alone.
- Every signed `Intent` field is displayed; no field or array is hidden.
- Nested call data uses the signed call target as its lookup address. Unknown selectors remain visible as raw call data.
- `value` remains a raw integer because the current independent renderers disagree on native-asset amount formatting; raw rendering is deterministic and avoids presenting a misleading amount.
- This PR does not add an `IthacaAccount` descriptor. Cloaked's live mini-app actions sign this `Intent`; the account's later ERC-7821 `execute` call is produced by the Orchestrator rather than separately signed by the user. Private receive and the mobile app are not live and are excluded from this production claim. Future direct account signatures also have a dynamic EIP-7702 verifying address and need an EIP-7702-aware registry binding before they can be described safely.

## Reviewer verification

The three fixture cases pass both independent clear-signing renderers used by this registry:

| Check | Exact version | Result |
| --- | --- | --- |
| ERC-7730 linter | `erc7730==1.0.8` | pass, no warnings |
| JSON schema | `check-jsonschema==0.37.4` | pass |
| Rust renderer | `llbartekll/clear-signing@0809971c81182ea93271759c62c04d1935415eff` | 3/3 pass |
| Sourcify renderer | `sourcifyeth/clear-signing-test-runner@3006d68e79c34278008000dff95a439d2b7c7665` | 3/3 pass |

The registry's own lint and schema checks can be reproduced from the repository root with Python 3.12:

```sh
python3.12 -m venv /tmp/erc7730-review
/tmp/erc7730-review/bin/pip install erc7730==1.0.8 check-jsonschema==0.37.4
/tmp/erc7730-review/bin/erc7730 lint registry/porto/eip712-Orchestrator-0.5.5.json
/tmp/erc7730-review/bin/check-jsonschema --schemafile specs/erc7730-v2.schema.json registry/porto/eip712-Orchestrator-0.5.5.json
/tmp/erc7730-review/bin/check-jsonschema --schemafile specs/erc7730-v2-test.schema.json registry/porto/testsv2/eip712-Orchestrator-0.5.5.tests.json
```

One deployment can be checked directly against Ethereum mainnet with Foundry's `cast`:

```sh
cast call 0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF \
  'eip712Domain()(bytes1,string,string,uint256,address,bytes32,uint256[])' \
  --rpc-url https://ethereum-rpc.publicnode.com

cast call 0x36A7Cd5b1F475122A2b52580FC8e170A2Cd312eF \
  'INTENT_TYPEHASH()(bytes32)' \
  --rpc-url https://ethereum-rpc.publicnode.com
```

For an additional implementation-level check, the three fixtures hash under Cloaked's production `viem@2.40.3` to:

```text
0xd6fa67701b861c0e8dec9a7947697efc18986185eefd61418835c384d23abff5
0x4b72f132efe3bc44e714da4fdadc56b5a0532bb08a7df0b78b25264fd6b1fdd8
0x2a4cf4486037cad97da5be39a4cc00f914c5fed43405574de8402c8e56b9b974
```
