### PR TITLE
fix(lifi): render bridge destinationChainId as network name

### DIFF
--- a/registry/lifi/calldata-LIFIDiamond.json
+++ b/registry/lifi/calldata-LIFIDiamond.json
@@ -5974,7 +5974,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6001,7 +6001,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6033,7 +6033,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6060,7 +6060,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6088,7 +6088,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6115,7 +6115,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6146,7 +6146,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6173,7 +6173,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6201,7 +6201,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6229,7 +6229,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6257,7 +6257,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6284,7 +6284,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6312,7 +6312,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6340,7 +6340,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6367,7 +6367,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6394,7 +6394,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6423,7 +6423,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6452,7 +6452,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6481,7 +6481,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6510,7 +6510,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6538,7 +6538,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6566,7 +6566,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6594,7 +6594,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6621,7 +6621,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6649,7 +6649,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6676,7 +6676,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6703,7 +6703,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6730,7 +6730,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6757,7 +6757,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6785,7 +6785,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6812,7 +6812,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6839,7 +6839,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6866,7 +6866,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6893,7 +6893,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6920,7 +6920,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6947,7 +6947,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -6981,7 +6981,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7019,7 +7019,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7058,7 +7058,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7096,7 +7096,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7135,7 +7135,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7173,7 +7173,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7211,7 +7211,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7249,7 +7249,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7288,7 +7288,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7327,7 +7327,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7366,7 +7366,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7404,7 +7404,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7443,7 +7443,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7482,7 +7482,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7520,7 +7520,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7558,7 +7558,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7596,7 +7596,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7634,7 +7634,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7672,7 +7672,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7710,7 +7710,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7749,7 +7749,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7788,7 +7788,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7827,7 +7827,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7865,7 +7865,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7904,7 +7904,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7942,7 +7942,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -7980,7 +7980,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8018,7 +8018,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8056,7 +8056,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8095,7 +8095,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8133,7 +8133,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8171,7 +8171,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8209,7 +8209,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8247,7 +8247,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8285,7 +8285,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",
@@ -8323,7 +8323,7 @@
             "params": { "tokenPath": "_bridgeData.sendingAssetId" },
             "visible": "always"
           },
-          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw", "visible": "always" },
+          { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId", "visible": "always" },
           {
             "path": "_bridgeData.receiver",
             "label": "Recipient",

--- a/registry/lifi/testsv2/calldata-LIFIDiamond.tests.json
+++ b/registry/lifi/testsv2/calldata-LIFIDiamond.tests.json
@@ -127,10 +127,10 @@
         "owner": "LI.FI",
         "fields": [
           { "label": "Amount to Bridge", "value": "0.2 ETH" },
-          { "label": "Destination Chain", "value": "4663" },
+          { "label": "Destination Chain", "value": "Robinhood Chain" },
           { "label": "Recipient", "value": "0x80CeDDd55e534Dd20AADd9bC091f2fE2b09FE473" }
         ],
-        "interpolatedIntent": "Bridge 0.2 ETH via RelayDepository to chain 4663 for 0x80CeDDd55e534Dd20AADd9bC091f2fE2b09FE473"
+        "interpolatedIntent": "Bridge 0.2 ETH via RelayDepository to chain Robinhood Chain for 0x80CeDDd55e534Dd20AADd9bC091f2fE2b09FE473"
       }
     },
     {
@@ -143,11 +143,11 @@
         "fields": [
           { "label": "Amount to Swap", "value": "0.0005652 ETH" },
           { "label": "Minimum to Bridge", "value": "0.000559548 ETH" },
-          { "label": "Destination Chain", "value": "4663" },
+          { "label": "Destination Chain", "value": "Robinhood Chain" },
           { "label": "Recipient", "value": "0x4171E66D95805afB73068ad810483E09f4eC7Bf2" },
           { "label": "Across Recipient", "value": "0x0000000000000000000000004171e66d95805afb73068ad810483e09f4ec7bf2" }
         ],
-        "interpolatedIntent": "Swap then bridge 0.000559548 ETH via AcrossV4 to chain 4663 for 0x4171E66D95805afB73068ad810483E09f4eC7Bf2"
+        "interpolatedIntent": "Swap then bridge 0.000559548 ETH via AcrossV4 to chain Robinhood Chain for 0x4171E66D95805afB73068ad810483E09f4eC7Bf2"
       }
     },
     {
@@ -175,11 +175,11 @@
         "owner": "LI.FI",
         "fields": [
           { "label": "Amount to Bridge", "value": "5000 USDC" },
-          { "label": "Destination Chain", "value": "8453" },
+          { "label": "Destination Chain", "value": "Base" },
           { "label": "Recipient", "value": "0x7D9d0DA1Ad30d4a707A473C9e91ecc100Ff065ef" },
           { "label": "Non-EVM Recipient", "value": "0x" }
         ],
-        "interpolatedIntent": "Bridge 5000 USDC via Eco to chain 8453 for 0x7D9d0DA1Ad30d4a707A473C9e91ecc100Ff065ef"
+        "interpolatedIntent": "Bridge 5000 USDC via Eco to chain Base for 0x7D9d0DA1Ad30d4a707A473C9e91ecc100Ff065ef"
       }
     },
     {
@@ -226,11 +226,11 @@
         "fields": [
           { "label": "Amount to Swap", "value": "0.041504476412942048 ETH" },
           { "label": "Minimum to Bridge", "value": "0.041400715221909693 ETH" },
-          { "label": "Destination Chain", "value": "56" },
+          { "label": "Destination Chain", "value": "BNB Smart Chain Mainnet" },
           { "label": "Recipient", "value": "0xb110fD66cB6D54dC0aE2b4C39aD8b8B2f6eCE387" },
           { "label": "Non-EVM Recipient", "value": "0x0000000000000000000000000000000000000000000000000000000000000000" }
         ],
-        "interpolatedIntent": "Swap then bridge 0.041400715221909693 ETH via LayerSwap to chain 56 for 0xb110fD66cB6D54dC0aE2b4C39aD8b8B2f6eCE387"
+        "interpolatedIntent": "Swap then bridge 0.041400715221909693 ETH via LayerSwap to chain BNB Smart Chain Mainnet for 0xb110fD66cB6D54dC0aE2b4C39aD8b8B2f6eCE387"
       }
     }
   ]


### PR DESCRIPTION
The `_bridgeData.destinationChainId` field in every LI.FI bridge format used `"format": "raw"`, so wallets displayed the bridge destination as a plain chain id number instead of resolving it to a network name.

This changes the format to `"chainId"` on all **72** occurrences, so the field is displayed as the EIP-155 network name (e.g. `Optimism` instead of `10`).

### Details
- Only the `format` value is changed; path, label, and visibility are untouched.
- `chainId` is the correct enum value in `specs/erc7730-v2.schema.json` (const `chainId`, "displayed as a Blockchain explicit name, as defined in EIP-155").
- JSON re-parses clean; the diff is exactly 72 changed lines.

The `interpolatedIntent` strings are left as-is; they reference the same path and will now render the network name inside the intent too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
