### PR TITLE
feat(uniswap): add 26 deployments found through Sourcify

### DIFF
--- a/registry/uniswap/common-eip712-uniswap.json
+++ b/registry/uniswap/common-eip712-uniswap.json
@@ -19,6 +19,22 @@
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
+          "chainId": 97,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 100,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 122,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 130,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
           "chainId": 137,
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
@@ -27,7 +43,47 @@
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
+          "chainId": 250,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 252,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 480,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 1284,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 1285,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 1301,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 2020,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 2222,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 8217,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
           "chainId": 8453,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 9001,
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
@@ -43,7 +99,23 @@
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
+          "chainId": 47763,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 48900,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 59144,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
           "chainId": 80001,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 80002,
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
@@ -55,7 +127,31 @@
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
+          "chainId": 202601,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
           "chainId": 421614,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 534352,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 560048,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 747474,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 5042002,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 7777777,
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         },
         {
@@ -64,6 +160,14 @@
         },
         {
           "chainId": 11155420,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 12227332,
+          "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+        },
+        {
+          "chainId": 999999999,
           "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
         }
       ]


### PR DESCRIPTION
## What

This PR adds 26 `(chainId, address)` pairs to 1 descriptor file. 8 of them are on testnets. The pairs cover 26 chains that the descriptor did not list.

## How the script found them

Sourcify removes duplicates of verified contracts by *compilation*. Two deployments of byte-identical compiled code share one compilation record. The script `tools/scripts/find-missing-deployments.js` (see https://github.com/ethereum/clear-signing-erc7730-registry/pull/2922) reads each address that these descriptors list. Then it collects all other verified deployments of the same compilation. This PR adds only the strictest matches: **the same contract code at the same address on a different chain**. Only one project can deploy the same code at the same address on many chains. So this match identifies the same contract instance, not only the same code.

Each address links to the verified source on Sourcify.

## `registry/uniswap/common-eip712-uniswap.json`

| chain | address | same address as |
|---|---|---|
| BNB Smart Chain Testnet (97) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/97/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Gnosis (100) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/100/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Fuse (122) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/122/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Unichain Mainnet (130) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/130/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Fantom Opera (250) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/250/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Fraxtal Mainnet (252) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/252/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| World Mainnet (480) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/480/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Moonbeam Mainnet (1284) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/1284/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Moonriver Mainnet (1285) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/1285/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Unichain Sepolia Testnet (1301) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/1301/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Ronin Mainnet (2020) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/2020/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Kava (2222) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/2222/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Kaia Mainnet (8217) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/8217/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| 9001 (9001) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/9001/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Neo X Mainnet (47763) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/47763/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Zircuit Mainnet (48900) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/48900/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Linea Mainnet (59144) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/59144/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Polygon Amoy Testnet (80002) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/80002/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Ronin Saigon Testnet (202601) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/202601/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Scroll (534352) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/534352/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Ethereum Hoodi Testnet (560048) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/560048/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Katana Mainnet (747474) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/747474/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Arc Testnet (5042002) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/5042002/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Zora (7777777) | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/7777777/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Neo X Testnet T4 (12227332) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/12227332/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |
| Zora Sepolia Testnet (999999999) 🧪 | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://repo.sourcify.dev/999999999/0x000000000022D473030F116dDEE9F6B43aC78BA3) | 1:0x000000000022D473030F116dDEE9F6B43aC78BA3 |

## Checks

- `erc7730 format` ran on the changed files.
- `erc7730 lint` ran on the changed files. The warnings exist before this change.
- `node tools/scripts/generate-index.js --validate` passes. The index has no key collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
