### PR TITLE
feat(flyingtulip): add 2 deployments found through Sourcify

### DIFF
--- a/registry/flyingtulip/calldata-PftNft.json
+++ b/registry/flyingtulip/calldata-PftNft.json
@@ -4,8 +4,10 @@
     "contract": {
       "deployments": [
         { "chainId": 1, "address": "0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2" },
+        { "chainId": 56, "address": "0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2" },
         { "chainId": 146, "address": "0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2" },
-        { "chainId": 146, "address": "0x1d8051c90076FaA5b683A3551Ee4369d00f99D67" }
+        { "chainId": 146, "address": "0x1d8051c90076FaA5b683A3551Ee4369d00f99D67" },
+        { "chainId": 8453, "address": "0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2" }
       ]
     }
   },


### PR DESCRIPTION
## What

This PR adds 2 `(chainId, address)` pairs to 1 descriptor file. None of them is on a testnet. The pairs cover 2 chains that the descriptor did not list.

## How the script found them

Sourcify removes duplicates of verified contracts by *compilation*. Two deployments of byte-identical compiled code share one compilation record. The script `tools/scripts/find-missing-deployments.js` (see https://github.com/ethereum/clear-signing-erc7730-registry/pull/2922) reads each address that these descriptors list. Then it collects all other verified deployments of the same compilation. This PR adds only the strictest matches: **the same contract code at the same address on a different chain**. Only one project can deploy the same code at the same address on many chains. So this match identifies the same contract instance, not only the same code.

Each address links to the verified source on Sourcify.

## `registry/flyingtulip/calldata-PftNft.json`

| chain | address | same address as |
|---|---|---|
| BNB Smart Chain Mainnet (56) | [0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2](https://repo.sourcify.dev/56/0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2) | the implementation of 1:0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2 |
| Base Mainnet (8453) | [0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2](https://repo.sourcify.dev/8453/0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2) | the implementation of 1:0xa4215Daaf3745E14E96E169E0E7706c479Ce04F2 |

## Checks

- `erc7730 format` ran on the changed files.
- `erc7730 lint` ran on the changed files. The warnings exist before this change.
- `node tools/scripts/generate-index.js --validate` passes. The index has no key collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
