### PR TITLE
feat(walletconnect): add 1 deployment found through Sourcify

### DIFF
--- a/registry/walletconnect/calldata-wct.json
+++ b/registry/walletconnect/calldata-wct.json
@@ -6,7 +6,8 @@
       "deployments": [
         { "chainId": 10, "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945" },
         { "chainId": 1, "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945" },
-        { "chainId": 8453, "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945" }
+        { "chainId": 8453, "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945" },
+        { "chainId": 42161, "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945" }
       ]
     }
   },


### PR DESCRIPTION
## What

This PR adds 1 `(chainId, address)` pair to 1 descriptor file. None of them is on a testnet. The pairs cover 1 chain that the descriptor did not list.

## How the script found them

Sourcify removes duplicates of verified contracts by *compilation*. Two deployments of byte-identical compiled code share one compilation record. The script `tools/scripts/find-missing-deployments.js` (see https://github.com/ethereum/clear-signing-erc7730-registry/pull/2922) reads each address that these descriptors list. Then it collects all other verified deployments of the same compilation. This PR adds only the strictest matches: **the same contract code at the same address on a different chain**. Only one project can deploy the same code at the same address on many chains. So this match identifies the same contract instance, not only the same code.

Each address links to the verified source on Sourcify.

## `registry/walletconnect/calldata-wct.json`

| chain | address | same address as |
|---|---|---|
| Arbitrum One Mainnet (42161) | [0xeF4461891DfB3AC8572cCf7C794664A8DD927945](https://repo.sourcify.dev/42161/0xeF4461891DfB3AC8572cCf7C794664A8DD927945) | the implementation of 1:0xeF4461891DfB3AC8572cCf7C794664A8DD927945 |

## Checks

- `erc7730 format` ran on the changed files.
- `erc7730 lint` ran on the changed files. The warnings exist before this change.
- `node tools/scripts/generate-index.js --validate` passes. The index has no key collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
