### PR TITLE
feat(morpho): add 3 deployments found through Sourcify

### DIFF
--- a/registry/morpho/calldata-MorphoBlue.json
+++ b/registry/morpho/calldata-MorphoBlue.json
@@ -4,7 +4,10 @@
     "contract": {
       "deployments": [
         { "chainId": 1, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" },
-        { "chainId": 8453, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" }
+        { "chainId": 56, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" },
+        { "chainId": 8453, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" },
+        { "chainId": 84532, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" },
+        { "chainId": 11155111, "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" }
       ]
     }
   },


### PR DESCRIPTION
## What

This PR adds 3 `(chainId, address)` pairs to 1 descriptor file. 2 of them are on testnets. The pairs cover 3 chains that the descriptor did not list.

## How the script found them

Sourcify removes duplicates of verified contracts by *compilation*. Two deployments of byte-identical compiled code share one compilation record. The script `tools/scripts/find-missing-deployments.js` (see https://github.com/ethereum/clear-signing-erc7730-registry/pull/2922) reads each address that these descriptors list. Then it collects all other verified deployments of the same compilation. This PR adds only the strictest matches: **the same contract code at the same address on a different chain**. Only one project can deploy the same code at the same address on many chains. So this match identifies the same contract instance, not only the same code.

Each address links to the verified source on Sourcify.

## `registry/morpho/calldata-MorphoBlue.json`

| chain | address | same address as |
|---|---|---|
| BNB Smart Chain Mainnet (56) | [0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb](https://repo.sourcify.dev/56/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | 1:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb |
| Base Sepolia Testnet (84532) 🧪 | [0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb](https://repo.sourcify.dev/84532/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | 1:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb |
| Ethereum Sepolia Testnet (11155111) 🧪 | [0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb](https://repo.sourcify.dev/11155111/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | 1:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb |

## Checks

- `erc7730 format` ran on the changed files.
- `erc7730 lint` ran on the changed files. The warnings exist before this change.
- `node tools/scripts/generate-index.js --validate` passes. The index has no key collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
