### PR TITLE
feat(tally): add 1 deployment found through Sourcify

### DIFF
--- a/registry/tally/eip712-tally-ethereum-uni-token.json
+++ b/registry/tally/eip712-tally-ethereum-uni-token.json
@@ -1,7 +1,13 @@
 {
   "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
-    "eip712": { "deployments": [{ "chainId": 1, "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984" }], "domain": { "name": "Uniswap" } }
+    "eip712": {
+      "deployments": [
+        { "chainId": 1, "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984" },
+        { "chainId": 11155111, "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984" }
+      ],
+      "domain": { "name": "Uniswap" }
+    }
   },
   "metadata": { "owner": "Uniswap" },
   "display": {


### PR DESCRIPTION
## What

This PR adds 1 `(chainId, address)` pair to 1 descriptor file. 1 of them is on a testnet. The pairs cover 1 chain that the descriptor did not list.

## How the script found them

Sourcify removes duplicates of verified contracts by *compilation*. Two deployments of byte-identical compiled code share one compilation record. The script `tools/scripts/find-missing-deployments.js` (see https://github.com/ethereum/clear-signing-erc7730-registry/pull/2922) reads each address that these descriptors list. Then it collects all other verified deployments of the same compilation. This PR adds only the strictest matches: **the same contract code at the same address on a different chain**. Only one project can deploy the same code at the same address on many chains. So this match identifies the same contract instance, not only the same code.

Each address links to the verified source on Sourcify.

## `registry/tally/eip712-tally-ethereum-uni-token.json`

| chain | address | same address as |
|---|---|---|
| Ethereum Sepolia Testnet (11155111) 🧪 | [0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984](https://repo.sourcify.dev/11155111/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984) | 1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984 |

## Checks

- `erc7730 format` ran on the changed files.
- `erc7730 lint` ran on the changed files. The warnings exist before this change.
- `node tools/scripts/generate-index.js --validate` passes. The index has no key collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
