### PR TITLE
ekubo: drop dead Amoy router deployment and fix 14 interpolatedIntent values

### DIFF
--- a/registry/ekubo/calldata-MEVCaptureRouter.json
+++ b/registry/ekubo/calldata-MEVCaptureRouter.json
@@ -17,7 +17,6 @@
         { "chainId": 42431, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
         { "chainId": 46630, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
         { "chainId": 57073, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
-        { "chainId": 80002, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
         { "chainId": 84532, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
         { "chainId": 421614, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
         { "chainId": 763373, "address": "0xd26f20001a72a18C002b00e6710000d68700ce00" },
@@ -155,7 +154,7 @@
           { "path": "calculatedAmountThreshold", "label": "Amount threshold", "format": "raw", "visible": "always" },
           { "path": "poolKey.config", "label": "Pool config", "format": "raw", "visible": "optional" }
         ],
-        "interpolatedIntent": "Send to {recipient}"
+        "interpolatedIntent": "Swap, send to {recipient}"
       },
       "swap(((address token0, address token1, bytes32 config) poolKey, uint96 sqrtRatioLimit, uint256 skipAhead) node, (address token, int128 amount) tokenAmount, int256 calculatedAmountThreshold)": {
         "intent": "Swap route node on Ekubo",
@@ -306,7 +305,7 @@
           { "path": "params", "label": "Packed swap params", "format": "raw", "visible": "always" },
           { "path": "poolKey.config", "label": "Pool config", "format": "raw", "visible": "optional" }
         ],
-        "interpolatedIntent": "Send to {recipient}"
+        "interpolatedIntent": "Partial swap to {recipient}"
       },
       "swapAllowPartialFill(((address token0, address token1, bytes32 config) poolKey, uint96 sqrtRatioLimit, uint256 skipAhead) node, (address token, int128 amount) tokenAmount)": {
         "intent": "Ekubo route partial swap",

--- a/registry/ekubo/calldata-Orders.json
+++ b/registry/ekubo/calldata-Orders.json
@@ -192,12 +192,12 @@
           },
           { "path": "orderKey.config", "label": "Order config", "format": "raw", "visible": "optional" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Refresh DCA order {id}"
       },
       "burn(uint256 id)": {
         "intent": "Burn order NFT",
         "fields": [{ "path": "id", "label": "Order ID", "format": "raw", "visible": "always" }],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Burn order NFT {id}"
       },
       "multicall(bytes[] data)": {
         "intent": "Batch order actions",
@@ -229,7 +229,7 @@
           },
           { "path": "id", "label": "Order ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Approve order NFT {id}"
       },
       "setApprovalForAll(address operator, bool isApproved)": {
         "intent": "Approve order operator",
@@ -264,7 +264,7 @@
           },
           { "path": "id", "label": "Order ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer order NFT {id}"
       },
       "safeTransferFrom(address from, address to, uint256 id)": {
         "intent": "Transfer order NFT",
@@ -285,7 +285,7 @@
           },
           { "path": "id", "label": "Order ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer order NFT {id}"
       },
       "safeTransferFrom(address from, address to, uint256 id, bytes data)": {
         "intent": "Transfer order NFT",
@@ -307,7 +307,7 @@
           { "path": "id", "label": "Order ID", "format": "raw", "visible": "always" },
           { "path": "data", "label": "Transfer data", "format": "raw", "visible": "optional" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer order NFT {id}"
       },
       "mint()": { "intent": "Mint order NFT", "fields": [], "interpolatedIntent": "Mint order NFT" },
       "mint(bytes32 salt)": {

--- a/registry/ekubo/calldata-Positions.json
+++ b/registry/ekubo/calldata-Positions.json
@@ -229,7 +229,7 @@
       "burn(uint256 id)": {
         "intent": "Burn position NFT",
         "fields": [{ "path": "id", "label": "Position ID", "format": "raw", "visible": "always" }],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Burn position NFT {id}"
       },
       "multicall(bytes[] data)": {
         "intent": "Batch position actions",
@@ -261,7 +261,7 @@
           },
           { "path": "id", "label": "Position ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Approve position NFT {id}"
       },
       "setApprovalForAll(address operator, bool isApproved)": {
         "intent": "Approve position operator",
@@ -296,7 +296,7 @@
           },
           { "path": "id", "label": "Position ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer position NFT {id}"
       },
       "safeTransferFrom(address from, address to, uint256 id)": {
         "intent": "Transfer position NFT",
@@ -317,7 +317,7 @@
           },
           { "path": "id", "label": "Position ID", "format": "raw", "visible": "always" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer position NFT {id}"
       },
       "safeTransferFrom(address from, address to, uint256 id, bytes data)": {
         "intent": "Transfer position NFT",
@@ -339,7 +339,7 @@
           { "path": "id", "label": "Position ID", "format": "raw", "visible": "always" },
           { "path": "data", "label": "Transfer data", "format": "raw", "visible": "optional" }
         ],
-        "interpolatedIntent": "Action for {id}"
+        "interpolatedIntent": "Transfer position NFT {id}"
       },
       "mint()": { "intent": "Mint position NFT", "fields": [], "interpolatedIntent": "Mint position NFT" },
       "mint(bytes32 salt)": {
@@ -400,7 +400,7 @@
             "visible": "always"
           }
         ],
-        "interpolatedIntent": "Send to {recipient}"
+        "interpolatedIntent": "Withdraw fees to {recipient}"
       }
     }
   }


### PR DESCRIPTION
Follow-up to #2556, which was merged with two review notes from @fbwoolf still outstanding. This applies both.

### 1. Drop the Polygon Amoy (80002) router deployment

`0xd26f20001a72a18C002b00e6710000d68700ce00` holds no code on Amoy. `eth_getCode` returns `0x` on publicnode, dRPC and Tenderly, and Ekubo's deploy record has no router deployment for that chain — its `DeployAll` run deployed Core/TWAMM/Orders/Positions to Amoy but never the router. The address is deployed deterministically (CREATE2, fixed salt) on every other chain, so it cannot later hold different code; this is an accuracy fix rather than a safety one.

While removing it I re-verified **every** `(chainId, address)` pair across all six Ekubo descriptors against the deploy scripts and broadcast receipts, then confirmed each on chain with `eth_getCode`: 42 of 43 return bytecode, the Amoy router being the only empty one. Code size is identical across every deployment of a given contract — router 11,122 B on all 18 remaining chains, Positions 21,978 B, Orders 13,528 B, VeToken 18,491 B, Ve33Positions 21,585 B, Ve33Periphery 2,569 B.

Two entries that look odd but are correct, noted so nobody has to re-derive them:
- **4326 is MegaETH**, not a Robinhood chain (Robinhood is 4663 mainnet / 46630 testnet). Its Orders and Positions entries are absent from the broadcast record but both addresses hold the expected code on chain.
- **42431 is Tempo Testnet Moderato.** Its broadcast run has no receipts, so it was verified on chain rather than from the repo; the router is live there with the same 11,122 B.

### 2. Rewrite the 14 `interpolatedIntent` values that named no action

`Action for {id}` and `Send to {recipient}` dropped the verb, so an NFT transfer and a swap collapsed to the same shape of summary. These now follow the `Ve33Positions` pattern already in the registry:

| function | was | now |
| --- | --- | --- |
| `Orders.burn` / `Positions.burn` | `Action for {id}` | `Burn order NFT {id}` / `Burn position NFT {id}` |
| `approve` (both) | `Action for {id}` | `Approve order NFT {id}` / `Approve position NFT {id}` |
| `transferFrom`, `safeTransferFrom` x2 (both) | `Action for {id}` | `Transfer order NFT {id}` / `Transfer position NFT {id}` |
| `Orders.executeVirtualOrdersAndGetCurrentOrderInfo` | `Action for {id}` | `Refresh DCA order {id}` |
| `Router.swap` | `Send to {recipient}` | `Swap, send to {recipient}` |
| `Router.swapAllowPartialFill` | `Send to {recipient}` | `Partial swap to {recipient}` |
| `Positions.withdrawProtocolFees` | `Send to {recipient}` | `Withdraw fees to {recipient}` |

Naming the counterparty as well (`Transfer position NFT {id} to {to}`) pushes these past the 30-character Ledger budget that `erc7730 lint` warns on, so the NFT summaries carry the verb and token id and leave the recipient to the fields — which is presumably why `Ve33Positions` reads the way it does. Happy to add it back if you would rather accept the truncation.

### Validation

- `erc7730 lint` on the three changed files produces a warning set identical to master's (the four pre-existing "missing display format" notes for `locked_6416899205` and `quote`); no new warnings.
- All six descriptors and six `testsv2` fixtures validate against `erc7730-v2` / `erc7730-tests-v2`.
- `node tools/scripts/generate-index.js --validate` passes.
- No fixture asserted on any of the 14 changed strings, so the existing tests are untouched.

https://claude.ai/code/session_013SZp6DHdgQrFNVYKn2QLTd
