### PR TITLE
fix(ekubo): do not show a signed swap amount as a token amount

### DIFF
--- a/registry/ekubo/calldata-MEVCaptureRouter.json
+++ b/registry/ekubo/calldata-MEVCaptureRouter.json
@@ -160,10 +160,16 @@
         "intent": "Swap route node on Ekubo",
         "fields": [
           {
+            "path": "tokenAmount.token",
+            "label": "Specified token",
+            "format": "addressName",
+            "params": { "types": ["token"] },
+            "visible": "always"
+          },
+          {
             "path": "tokenAmount.amount",
-            "label": "Specified amount",
-            "format": "tokenAmount",
-            "params": { "tokenPath": "tokenAmount.token" },
+            "label": "Specified amount (base units)",
+            "format": "raw",
             "visible": "always"
           },
           { "path": "calculatedAmountThreshold", "label": "Amount threshold", "format": "raw", "visible": "always" },
@@ -311,10 +317,16 @@
         "intent": "Ekubo route partial swap",
         "fields": [
           {
+            "path": "tokenAmount.token",
+            "label": "Specified token",
+            "format": "addressName",
+            "params": { "types": ["token"] },
+            "visible": "always"
+          },
+          {
             "path": "tokenAmount.amount",
-            "label": "Specified amount",
-            "format": "tokenAmount",
-            "params": { "tokenPath": "tokenAmount.token" },
+            "label": "Specified amount (base units)",
+            "format": "raw",
             "visible": "always"
           },
           {
@@ -360,10 +372,16 @@
         "interpolatedIntent": "Swap {s.tokenAmount.amount}",
         "fields": [
           {
+            "path": "s.tokenAmount.token",
+            "label": "Specified token",
+            "format": "addressName",
+            "params": { "types": ["token"] },
+            "visible": "always"
+          },
+          {
             "path": "s.tokenAmount.amount",
-            "label": "Specified amount",
-            "format": "tokenAmount",
-            "params": { "tokenPath": "s.tokenAmount.token" },
+            "label": "Specified amount (base units)",
+            "format": "raw",
             "visible": "always"
           },
           { "path": "calculatedAmountThreshold", "label": "Amount threshold", "format": "raw", "visible": "always" },
@@ -392,10 +410,16 @@
         "interpolatedIntent": "Split multihop swap",
         "fields": [
           {
+            "path": "swaps.[].tokenAmount.token",
+            "label": "Specified tokens",
+            "format": "addressName",
+            "params": { "types": ["token"] },
+            "visible": "always"
+          },
+          {
             "path": "swaps.[].tokenAmount.amount",
-            "label": "Specified amounts",
-            "format": "tokenAmount",
-            "params": { "tokenPath": "swaps.[].tokenAmount.token" },
+            "label": "Specified amounts (base units)",
+            "format": "raw",
             "visible": "always"
           },
           { "path": "calculatedAmountThreshold", "label": "Amount threshold", "format": "raw", "visible": "always" },


### PR DESCRIPTION
Follow-up to #2556 and #2950, fixing four fields in `registry/ekubo/calldata-MEVCaptureRouter.json`.

## The problem

The router's `amount` is `int128`, and the sign is load-bearing: positive is
exact-input, negative is exact-output. Four functions display it with
`tokenAmount`:

- `swap(node, tokenAmount, calculatedAmountThreshold)`
- `swapAllowPartialFill(node, tokenAmount)`
- `multihopSwap(s, calculatedAmountThreshold)`
- `multiMultihopSwap(swaps, calculatedAmountThreshold)`

`tokenAmount` is an unsigned format — it reads the word as a magnitude and
renders it with the token's decimals and ticker. So an exact-output swap, where
the amount is negative, displays as roughly 3.4e32 of the token. That is not a
number a reader can recognise as wrong; it is a plausible-looking enormous one,
on the screen whose whole purpose is saying what is about to be signed.

## The change

Those four now show the token beside a `raw` amount:

```json
{ "path": "...tokenAmount.token", "label": "Specified token",
  "format": "addressName", "params": { "types": ["token"] }, "visible": "always" },
{ "path": "...tokenAmount.amount", "label": "Specified amount (base units)",
  "format": "raw", "visible": "always" }
```

`raw` is the spec's "natural representation of the underlying structured data
type", which for `intN` is signed, and it is the only way to ask for a signed
integer at all — v2 has no signed-integer format. The reader still learns which
token; the amount is in base units, as it was before these two fields were
bound together.

## Notes for review

- The existing `testsv2` fixture for this descriptor covers the flat
  `swap(poolKey, isToken1, amount, ...)` entry point, not the route-node
  variants these four are, so no expected output changes. A fixture exercising
  a negative amount would be a good addition and I am happy to add one with
  guidance on generating the `rawTx`.
- Found by a corpus-wide check in a downstream wallet that reads every signed
  parameter in a descriptor and refuses a formatter that would drop its sign.
- Worth flagging separately: a renderer that puts `raw` through an unsigned
  big-integer conversion will print a signed value as its two's-complement
  word, so `raw` is only correct here if the renderer treats `intN` as signed.
  The spec's wording is clear, but at least one implementation had them sharing
  a branch.