### PR TITLE
attestations: re-sign 135 descriptors over resolved ERC-8176 hashes

### DIFF
--- a/registry/1inch/sigs/calldata-AggregationRouterV4-eth.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/1inch/sigs/calldata-AggregationRouterV4-eth.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x18b340dbefca3736477deacbfaf6ab983cba585c8ed52d38586580e3b4ccb0f4",
+    "uid": "0xe26444fb983e3439d217ceaa9b62a693d4475c28aa744cd202563a07108c621e",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x9f361b260845433467e4f0f47d1ac26bebdef98b050f9fc1dfbeed3042edd573",
-      "salt": "0x1ae1f2c3db16223a062ae47965507df3884cb86c2f5421b6932fd83aa6c7fe14"
+      "data": "0xe492e54fa2a22f2e9c5c98d343411e41bbe991c637395e8e4d0b927442062634",
+      "salt": "0x1202e6e2593930f4f63628c21e3a047d9a0428ee320e573b4a720afefe177521"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x712e5b7aa6707781858813980f47c36ae4764ddd184d69e6b7c3fd1b447a6cce",
-      "s": "0x138d9338c2ce8258744516fcde12ea1e3248b4bf79e14554f6127b8776e5a264"
+      "r": "0x4e0fad0d7631ac085d2ba56257932482aebb0b9923a3f6e7fc2a2d12a5a3e75c",
+      "s": "0x78580bd624689e5fbdde55d03e4ec7e95d4af667bd36f98d35d9e5e0a3df78e7"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/1inch/sigs/calldata-AggregationRouterV4.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/1inch/sigs/calldata-AggregationRouterV4.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x10c57fdf45da38af9f30561527c51793a8e9fe7acfe0b5a040413474cf87d195",
+    "uid": "0x7307282ce6b7bd7c6633dbec6f2a6a3e8e59806cd8ba97a067e5ad0e4abf859d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xd55e8bf5140bb9635522cf3d1a142e4dacf7c05d902fc5ae3d4358f82b57c4cc",
-      "salt": "0x6171e68764e57624fbeb2d027e08aa34d27d8d91966338f3d08a9723e5f7a2e1"
+      "data": "0x0039d2ccc41196701d4fd730dfa2ffaac85d99ba57e03b8fdd443a63a7d923fc",
+      "salt": "0xdc25afc24c8262fa70b403131f7abc9191bf22b9c28f4585f87d5769a79bad21"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xe4e7373aa8e94b8147b0da0d590c217027209ef184f6f9791191b927775f5e1d",
-      "s": "0x7a41b099bbd065a9f124e2bb5a1d51fd6c3ecfd50898c0962e4f1fdfe127b793"
+      "v": 27,
+      "r": "0xda82cd233635db7c3692fb8f88bc51fbcbb223e431393a05cac7adb5dc1fff84",
+      "s": "0x77b52896f41391fc3bd84dace883fb94aa0a213f9599d2aeeefbe4ae20160950"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-EURC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-EURC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3bcc47f34bc3fd9529134fd643668a3eccb478e632d5905657968fb5872de3f9",
+    "uid": "0xa57b494a2475ccdc5f0d113f71bf81ca7dfd528d45b6836b0e7da8ad68f96ff4",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x63319710bf44e6384b810109d40f6b18b4f02df5a18ef8c8bf3720f6fccaf25d",
-      "salt": "0xa3624d9732be63b52de1ff9c0a34de7e7a37f5766e8e11927d6cb7742ead71c5"
+      "data": "0x552d8cb4f4cf20df66427036d1c601284bc477347ff6541aa5ea752cdf50e193",
+      "salt": "0x3b5827f3084c6d74a24438e880406fa77c83f330c7138f5872b7d1447cdcfe6e"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xd55cfa9d1d776c740886e4cc193af3bd304be23174b9afd37cd367c015473c18",
-      "s": "0x72e6c21ae5accaa7b7813d1a191b59ec122e2c3882301005431d12f0205967ce"
+      "v": 28,
+      "r": "0x158522ba19d4e747165275528035a819370966bc3b11f596aea2057fe19760bc",
+      "s": "0x71bd0ecbf81fc60cfb9c939c197e57ba310aa8cd14f152fafc32617d72dd0d60"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-RLUSD-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-RLUSD-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb96cf18bfd6a6ff803349dbff786a37d326e83d9545036d67886f0985c57df6e",
+    "uid": "0x0d635af7b8fad05f06003103f7e0d1d48bd51268ef34fb194b394a83ed7d52e1",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xba56c76c2b5674921b24b74864fae80194d3b15855fdd521543b1a54b0b9f0ce",
-      "salt": "0x7c5e2652324a3ba9cf22585c3ea79978d4513e4dadbc7b4a551f2ab4f7afcc5e"
+      "data": "0x65ed790de5d6d8588619a5afd9e2f4b844a61c864a3e410d35de8e2430df67ee",
+      "salt": "0x44da58bdaf39a1039a53a6285e521acd6f0fa6ddfcbe5f2c5fefe3d727535497"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x7cda30bd86b5a6ad01090015b0f5d1bd2a05ea758e0baf9357eebe1924affbaf",
-      "s": "0x5bcc1783161fb5b951f0f72aceb16409b0d2ed08f3a482a4f9bbaa32135a477e"
+      "v": 27,
+      "r": "0xdd8aae58ef438d15b9ede45d8fef19fd0042ea089c711b5ab8108004ae688e9e",
+      "s": "0x4468b02cb1b0d1b1f481887354f935eb10a06c05ca3094d2f0a7b827abf3b9ea"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x5844c722323fe3724c4ec2da483972d0ea79e0e2068292f2375747724477e5a4",
+    "uid": "0x5220853852412b31cd0db8da127178c98a4e60dd5dc38d15d8166deb99e4ec96",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6017a2c8f94e125d7cb77c0d63cb4effe52be64c45d09074c77d371b0f46ebf7",
-      "salt": "0xf444c49673dd82f325940577ecabd189e53b620e8c42786cc187deedcf060832"
+      "data": "0xdf1a3094a211b10a1541d51e112fbd51709df48dc42ec7d92a08634aa33460b6",
+      "salt": "0x594a194261a958c41466f1fe4fd31b8bfa65b2110ffc1b3447366b4e180c4b8b"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x07759aafbe9301763280056408b22d5aec72c54397fac4c100b7b2527f40812a",
-      "s": "0x7cc1c2d63e8047ba2c62ded059f84ebf48da558fb437f88ea647ea79803407d8"
+      "r": "0xb24182fc08898be17c4f0f21752242b3230b54b857403c9a715af6eed376ab56",
+      "s": "0x335f235105c9fddc27c5c9915aad4e8eafc7691da656d0c54019a727f9c08c9c"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x5f0fbc82f4acee14be520c6da0ebed9a11bdff13ca8bb94cfb8a88f8333757a3",
+    "uid": "0x546c300b9fdfbeffeea488169d7bdfae6fd861aff5ec51a6bf8cb876df560693",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe19b08734f006b5fbfd31caa86baf8dab18b319cfc1484d9c8d5aa454401cca0",
-      "salt": "0xc1508c4361082f88e81fa2c429c1c5c81c3b62efe05aae4a31f75b2c9f5f63ff"
+      "data": "0x0f21ddfa5a7efce099da09f04ba619803c985f3e2db8ad92fc00caf59d94acd6",
+      "salt": "0xb2451e19ec33223bbc708425bcb3f8f73ed21af7e8c247ab46145301203ddb6b"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xb4a8df1dcfb748eb21b0c34d24f848ca932585a3ed6a6e72f8713c19c3aba928",
-      "s": "0x60dcd58a83c7344d61e70a00cf9fc53322bc3ccdc59ec81cb150ea5ac07a1f3c"
+      "r": "0x75457a398e0d78268e574a9524248a0a25b2724a39d7afb2977f997f60124df5",
+      "s": "0x71e6f3d04379b0a226c8f8fbc88735d05dcea2134e72c8dc9f949ee143e560c3"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Core-Base.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Core-Base.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb49abea9ff3dd9562634bd5ba12891b85f0cc07fe28ca1ae15cf8b63429d49dc",
+    "uid": "0x0ac330ae0e5711ed49d604ca9fa0359e723c61a565da44d136e2ccfebefc44fa",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6c013da68350d1fdfb3e3da46037c0ef0e2b2a0a60b466c4b22baf62cf2840ee",
-      "salt": "0xbcc4b4c2f1c4d8ea9b90330095e570d6740a3b4a6a035102b8b9779e7f1e9834"
+      "data": "0xa6c6549e8e48b98931738433c37c180c79eb6905e0c4f4b821da4599de960406",
+      "salt": "0xf4f50744e9665be07646e899592f728cb4ac2ab62a908fcaee0d020831631754"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x6295fff54d1f1c0b4b8e06d1a3e8b377ee13408179db88c5d9121e41730e38da",
-      "s": "0x68318e145a398be866d5c742868f5f74cb00b8744a3a43da13b2276ac95fed73"
+      "r": "0x2e8b5c26ecc55b9da4ae9b6643cd72e7bbdaba8c46ddaafb75220c5aa8bea8e8",
+      "s": "0x2c80b62b4d56a51bbdcf18b7b58a4b8c68d4854f65824319da88a3234805cf2a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x9a4181b01939e4c67d4676f41a7c004c8f4e20008e7113ce992cdf084c31280d",
+    "uid": "0x06f7619db6326d1db2d46abdb9522e8a37bfdce1cc130a48f9ed0c4400dff8de",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x357190a95043f3837e89236fe2cecb6bfd57a1e161d68000e0d0eeab3cc3b7b5",
-      "salt": "0xafbc39d941309971748bcd87c5204470353dd863d6318305970fcf7ee9b5a2dc"
+      "data": "0x8943b906e91f5095feb2ae8fde690e2ecf9313fc692d9ab1e8049c02924b3383",
+      "salt": "0x42f8ecbc53b09839e9af12e60fde1e7f4f8b8429a7a343a021c807e5e49da1a0"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xce9fb447c4e4065d6db804f87ce7d2f1fe520a77afde2404e48121aacf0546be",
-      "s": "0x319970b6cde86f7d5b063133ad8b8101edafabfd541d2c0cac6fb1ad0c30e160"
+      "v": 27,
+      "r": "0xd4a28c0f4faea9f3a31d98e240ed7acfc870c75d13c86f7ba5030a9995747075",
+      "s": "0x0ceda396220132a57fd0d2cbdad5b2cd9a2d407ef431e3ebadfd174b0a156934"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x643e1b9882cc6677f8ac15f1ac0fd860773b70e809a5a9c3482a0e45a6af8386",
+    "uid": "0xfe5d756556927e08331e20dbaee206c2f6fd6859830c03bb93ebcbd70bbb4678",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xd600c72a2fd1fc9b194eb6435be677ae87e82239bd9af81297898efc0288285a",
-      "salt": "0x60958e62fc7e7b501953024533db72ef20bd169598ae8a5d5f29a288853e877c"
+      "data": "0x09b1a2e09d2806ce56061ad7251c5af8e63959707893c89068cb04a0b70a9769",
+      "salt": "0x33ff61d0974612d5e80f87d5317757a21c641e3fc18c21bdc51ed4fddfc5da02"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x9ae2d09b2a65e30119663729334a90839d78d915954ce6d6f4de2b18af037fdd",
-      "s": "0x780c2889de407a8dee69a0b381115df21b954ca3179f33869de9ab91aefb0d66"
+      "r": "0x00f561de02622af5450043c6e1c88b28ccb22c453eecbef79e9b5723f8ec99ba",
+      "s": "0x3a2c0243c19a27f633fa918256773ecc4d66b3eec37cef2ceec47d56addf5a6c"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-USDC-Core-Base-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-USDC-Core-Base-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x7c8292c812b994e468c1bcb3213759209f18a773fec4e982002e850432820668",
+    "uid": "0xa0592aa51fe90795b14a34e949b5671433e39c5416e90472c1f7c18c9518a253",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x256885ab4557e7374a1a9320e9f888e5c5db4afc82b1c927c75bbb8cf4e8e7f3",
-      "salt": "0x48b03ee99d946546dafbe3edea06b1f8fa7cd503422e291b06eff8b1160c744d"
+      "data": "0xfdbb421315a0c48def23f93501ba350fb382d97368246c799c20455b3498d58f",
+      "salt": "0x432247eb070013d9d3dfe8d92593cfcbc005f657b666833e8d1b5ade11a7753d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xed5bd58e1b352388fb70953b000ae4feabd3bb2ee235507da6a16086c9a91ecb",
-      "s": "0x36e88b91d9f16c50bc9861b3f9a3d90bd08cfba33496368fbb780d27378c6171"
+      "r": "0x6ce6b36a656e91b0ed99ffc1eee0133e949bbb283a45680005a95b68875852e4",
+      "s": "0x0db1a08972c6ac45d98bfd17312e24dcacb8234292df1c109c43b86c60785526"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-USDC-Core-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Gauntlet-USDC-Core-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x0f85432c01a45f0abd51c40e773d461d6129bdf1edae2c66f9df889cf54fbe34",
+    "uid": "0xa50b8e17c583e43452d46d8615be043d2c9bc545d5ec0060f256693a1e5b6079",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6a57cf8de0b7280fea60c6c37e1d6e868a78715b63e214f2c29b4ba41929d396",
-      "salt": "0xa1ef595b2d2ff58d64a7a7c07332da2e81930d6cb04d55b702bd5fce1fe8f2b3"
+      "data": "0x0621e25ff4e1a33f960a2658425bf886a760be4e6d0dcd893ca16c84eae5b391",
+      "salt": "0xe11915b0e846f50ec8074472d82c5c2159b741f8c18ca9dc96463efea7848f5d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xb10c5052458bc3acfcfd432f7b93bbbf7a66c180f814da68fed92785d2cd7f69",
-      "s": "0x11a7fe47249bb1a3d549a640ae5b738bb5c2abfce92c4930fec7103e59ce9f69"
+      "r": "0x7b3fdff93df613acc13a88877c8e440d22cb0de4aeab93cc977dfa03a097a7ea",
+      "s": "0x62c048718193bcb61902ce242ac4d7cb4a3abac6a100b6ff324dd7bae736e358"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-MEV-Capital.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-MEV-Capital.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x6ed75a7748a84dba736544b0aee7ed5415b78de638e92cd7a77b90ae82622433",
+    "uid": "0xf3d120255dafdac891b66f23a70ce7d39593f08914521853df43f53d34d74492",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x7eb233e0eb3047f09a2c350a5348c71044d5ce612154a1fe5889bd115c5a4305",
-      "salt": "0x5e4438f101ac4247a2256848d84d33afcf9162a70c7d2e28363372e18339d939"
+      "data": "0x8883d13cc87552255d43a9fc095791208ada175b3e612b690ba9d0b9ca596461",
+      "salt": "0x1b5d3dd6257c12a807eb527989f9723b880d849d5f91043c053f9122d3f43d36"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x23c326d536ce391f65404a4c1065427dcea049b2f6d3ca36951f9d56e8ab3790",
-      "s": "0x72675b22440a1d159fc07d00b55ebb0b747ca1527e81e8e249a084dd4d9e8250"
+      "r": "0xc16c9dfcaebc54309da9e09715c3e5a34997e5545de9ec0aa8dd89aeb851a72a",
+      "s": "0x55f828f2be7693a30ec1b51d420201df42329ba479f25da6d88bf74cb7cf52ac"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Re7-Base.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Re7-Base.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x16b5693d5ed15524d38745435d6087bfd3a1d88559afbb1f175f367c32632755",
+    "uid": "0x3529da903af68d032b83def543e502bc0c5cb563ba240ef2478147744a61d004",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x05657ae0a6073e0642f6aa273bde9bd605647735337acdfae54ab6a32cecaf7b",
-      "salt": "0x94efdc4d2fc7c4f57aaa87a2f2cf9d3c818ef328cf9f74793e645d0a6564cd9a"
+      "data": "0xd8853194a3daa7e101bb49e037f73eb320da992b4b5c890274148530a8cedc8b",
+      "salt": "0x4dbb7141e16e16c32dadfdf6f81aa5b67e0bf376b467c878ff0c7d713f479208"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x9f78c7a08aafe4fa64c8bbf45bd9b55c7dcef7a86b7324db7f310230e7ea1f4d",
-      "s": "0x1651b9bb3fb72a3703c4f1c680d567f4082c6cd499510aa08bec250e848044b1"
+      "v": 27,
+      "r": "0x918d94bb55d4addafea45081ffc50ae347b3dd92646eef6bdad9519c6dee4539",
+      "s": "0x7ac0de0aec931f0fd9a6c0d19d8d328aa28c35c4f489b814e7d1c4c30f37863e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Smokehouse-USDC-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Smokehouse-USDC-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3accc952dfc1117a19b0d515ad0901ebd1d01f8824edda82ce90a331c3586250",
+    "uid": "0xcf5d3d09bcad2df19b72e714a916546e8c889216eed3f5bd5b8cbc2a27450583",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xf5928cea34049f2de991d2fb70014c98ad60f60bbdc9f345a76f2ee9d25af964",
-      "salt": "0xf8ab15ee3368159b6f708e03457ab8eeb6f2032c015ab9deb60d3e5249c9971c"
+      "data": "0xa05915ce8b8cf279210257231b24ed19f635ce3860ec020c69726b1357013e7a",
+      "salt": "0xcaa49db93b1c12e39834cd06d6f569ef733f42cf5d4c26406dccf40f6172743d"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x6efe09e3abb218854321fec3d83669cc9597f854f3de08c62197dfd49a5ed32b",
-      "s": "0x153fe262de267266f880a2aeece9abdb3d3cf6814f875a918073bdf052cb7a6d"
+      "v": 28,
+      "r": "0xafd8a1e4619681f1da82bdefa10092f1bac4e8eb723ff8b74354b324a0d9d231",
+      "s": "0x6419e6f300c2723ce8a2ce64d87e2dbf37cca52007c69b29cb65b0897878e0f5"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Steakhouse-USDC-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDC-Morpho-Steakhouse-USDC-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa1b6fef73810fbdd9370b4b9bb73d9aedbbbec52521f3d00d8c745bc24b0f1c7",
+    "uid": "0x030a144ac4717f497d237b5f04b738032e0366f0bf5ed5926773087cb4a17c85",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x017cf06cd142a6ddd03a9e8e89de97b5c321bb9e365ea6f55df30cb8ae8fb9c6",
-      "salt": "0x905c9073940bcff8a16acfa7fb8eae20e9be3a5816ec3c1487bfc214664dcaf4"
+      "data": "0x355a1a6aea84b6e437ec95a245d06479b9017b9fbce9c2260202467e469354eb",
+      "salt": "0x33a1a546061d7901c4b4cbcf5ed4c6020eb61a9c8b1d396d1cc39bd294f15fe4"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xbe3f4dad2b075ed45e0e6f52d68ea0cb3fdd0a3a8661fcc29eb992babb4d36a5",
-      "s": "0x0ae9e737f9d155b79c45c611dfe711144be40cec42e00e92d6648ad74ffd3000"
+      "v": 28,
+      "r": "0x60a6f8932135d5c74b007ab4c4ad18a1b72b20d812081bf58abb0353bcbd4add",
+      "s": "0x60b84ab358211416fe5801f02396dca9f5a777ba2e6f7c1f4c947d60325df4ae"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa9c69e790917673ba0deadfedd3146d238b6a90679e2ef8a7fcb0e0e0b375218",
+    "uid": "0x175a700856c34a2913c498252dbde0d7d0aa1b3283dbad54638013e8e9c2cdcb",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4b371452c5e383d2f8727162c505ec07b4c1211640b0474a1b8b5932b70e043b",
-      "salt": "0x0ede34109c1502356c6b0b686e2bf8d515715cce0f96364a6f0a7f20dfd336db"
+      "data": "0x93f034cff0822cfcd849433d2531c55788a86a3bcbf62f8a0e6adc40cb4a2d20",
+      "salt": "0x715718dc33b563edeca2d2bf07392465d8ce7edafce6d02e0d287836154db77d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x05a2505a6e454cbe8a1fd45bb35f646a3efbb6fca2ff537353715893bdabfde1",
-      "s": "0x767639c7f00efb9da46a02557f856e64eeccff48635c4a221ff59e5bafe4953a"
+      "r": "0x9cccf68857560ba594e5b43723a0fb1034906cd544b6e43d0ed36da8f1b6414c",
+      "s": "0x223f3137fb7e806967c5017b71af724bc1d7eeb30ff05b3eb0ac79f3cfe6eaca"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Compound-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Compound-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x908f4ef70619dfe0bce18f95b25128a8aeb521485032f580a95cc06dae8d0dfa",
+    "uid": "0xe5576f26dd6b1cd9d5aa481e46cd9636bb77b6763f45649ed8bf8f3d17a53056",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4d9bcad84609ae10ccc3031aa7fdbfa0ad41c51f8e763a2b39c00b16cc972752",
-      "salt": "0x66eefb1bafa9ccdcb6c838a23bbeb1b8fd6d4ad1b50801827e594b7977a8dae0"
+      "data": "0xbebdbb4b2a66e8bc275de0ad49daa9b47b07b7e52c8839d1da808d686012c3bc",
+      "salt": "0xc6d944e8d99225292b6082bd21b32c5f3206bbf87bbe36ed7ab5d6cf5cfce51c"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xe33474bfd84e5fedc2adcf9c48915901f0269776d513e116308c11c5ac39e5bd",
-      "s": "0x7c08f3cf1c5b570e3ead46ca13f458e119acf91eb72b7b95d4dee5f736f28238"
+      "v": 27,
+      "r": "0x203e394f59c1da20dd89f8fc8b1bc6e89ce98c495542c8846eee3d57b57d7549",
+      "s": "0x2c9095acef18ea3d7181d2d261dbf814f53535be4da6ced4698fd6e8bb62d4d0"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Euler-Yield.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x46be8a7476361252eb383780cca463a369fa4446cc2025545e724d5e36daff37",
+    "uid": "0x62fa296f2866fea99e12855d1983ffd2589f62985250682485b559a216ff3450",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x1b20cdbd48a9bdd09aa67e0e79e89581d9591ecfdf7fe7614eb41e87f0ad6312",
-      "salt": "0x9448b2c04e554f8e646eebedc92d3bfc1daa4fcbe19de38c16ba09fa9e690574"
+      "data": "0xa14fec72d5228614cf0b1ebe8226b559c75a402a57f729f5447391f653308c8a",
+      "salt": "0x54dc56ca3ea37eee9e2e4d12886b30a3f883e0421e77ff93d15c0f5124730b4e"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xc280419e95bc6ea971487365867e3ea869cce40d9ca88ee446bc422617b41604",
-      "s": "0x60bc3a7a9c64ed6b41b9fed768eba7586d06193b838b802d41f0c002a51bbf71"
+      "v": 28,
+      "r": "0x3c9ffbcc5633b39500518b1996ecfb1b89337535a8db6033ac15a10e1dc7aafd",
+      "s": "0x6b78adda72f75f9e9408dc10d45472b4a90b400b821e5ef332a00c5311ca8e94"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x4125b0c924c6119639598fdfaed1026d1fcf8ecbf872276ee0dc9a5a3171edac",
+    "uid": "0x15753adcd03a052d39e53151615b1d0af3288f7f146866fddbdf5f6649173070",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x1caf00b1bfa3bdca7ad3fd5ec66cba6be38d459cc46d49e60b44ab9b560f6cd6",
-      "salt": "0x8941245715f4a3a44ef0df21adf40d6c86202c620331a02b488a90ee6c925b6e"
+      "data": "0x05ad776f139a112c7b7b9cb65cdfa0f41277cac379f6d92f48bfdb944ec69f37",
+      "salt": "0x21d6e93dd02e8c115eecebc0aab470f29582157933dfacce00a8b9baf7b3e060"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x8ff0db3005f6136af008fc3f26c338bdba2f617fa460c6fe86ba4fcae039368b",
-      "s": "0x5aaae330de9fa8e78dcd30e6d7eb46fc5c0d64939d43b87b57c990c034c64ec2"
+      "v": 27,
+      "r": "0xd035676492c124a44f65685cfe461fe2bdde6db3cb3473e10dc5a1232fa183d1",
+      "s": "0x5da6020cc7793741b2b7eba99c322df57e5d261ed02bc7a59962e48e6ee444aa"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-USDT-Core-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-USDT-Core-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x58c8fdf8387f92a907e7ad5f1645be7ed2ed7723788bb00f7c982b9812ae4f3e",
+    "uid": "0x490145eb7a46bd7dbcf37d6ecd8faa95a46f98f9c510302c6bb7a272e88c142b",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x8032e23ef73e7344b04351969840815f4260757d57e5985fc6f5ef4435e9e954",
-      "salt": "0x8f53102bf47e94c40fa5e7f27d2f22119fe8f5d3ad95a589ded3af3539b36299"
+      "data": "0xd5c9c6b39fe1c29507a1fd3f1bdc8a2e5fce8c5b1c880795918824bd3cdaea8e",
+      "salt": "0xdc80ed71984ee99d3b61bd138e1fd25ac95967736bf1fc39b798bfba42187138"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xc05ccd32ec9dd26d060f274311fb1521cbd1e1f60124b1ad0d3b348954402848",
-      "s": "0x4a10bbbef3171775fa2eaf63fa4e954d21ad97f470230d5e6564a4ef22bd3e81"
+      "v": 27,
+      "r": "0x3b2a4a863d7a4c832e94a9a46a4024160c6b2d04130914894648ebfbb5fdbff0",
+      "s": "0x444d08fcbc3733a6a65c7716ce2303dfaf1cd52e6897e3b16d27e6dab0679f99"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-USDT-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Gauntlet-USDT-Prime.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xbb97e6ed7253e2503c785a4062628f403378cbba54049789dfc481bc28b216d7",
+    "uid": "0x79d997cc31adc5c3d9d2c3ff19d6e1c1c0161f252106fc50034a7f32ddc1bfae",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x942f6e4ac78a15568e5356c0a033e844139b3b9c36639481adf14a8db2c418a4",
-      "salt": "0x54ea33179da3cddf2e99154b205cfb510998714ea615a7e38613a72504e4c95d"
+      "data": "0x4c1309e3c055ef1894ec7eafaa2306e3e6d60012c55252bf0e0b624dce553a84",
+      "salt": "0x26e111f73a4c910a4e1f22dfc6603366a0f9d0612388cc12f1d98f8ceda78e2e"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x18b3383b350a201d223a81388241611365a142be84ad346928162f3e4ae65cc6",
-      "s": "0x3824236f4c599133c7d7381f123af57774898672a26e990cc2d9d7d195d8d66d"
+      "r": "0x682eaf122701ea3a0a212731629b8251b3c92bd7f09c0a0fe44eec74780233bc",
+      "s": "0x244ccd97651a2e11af43bafa30bc0d790e26b4aa1fa904cd2d9bb42faf26d29e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Smokehouse-USDT-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Smokehouse-USDT-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd74a0908992b8b04cb9aa3920f1c970d7143124c1071987a3b0f79bc4ab15493",
+    "uid": "0x7884feee0b0efd31d1bc3ee3b20b66832aa350b97157434d5fbbfc5a42b7ec5d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6b0b8d8e4393b33429aa1a361cb894f5a3256e2661f8499e5fcdc05b0c1829d1",
-      "salt": "0x218b3fec958f935421613d75e11336117afdbec62c809c08cf7025cc0939c0be"
+      "data": "0x1cb052bbbe2f9830d015dcc39f4f680a313c091b13007936afc62ae6c946ca43",
+      "salt": "0xd84824ca1cc0d0ec8aae060ec11e07edb92f844b23ee18bc5b1fe67810547936"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x7d89194b373445325e7b303ce01e2c8a3a5d992dc24b10fe460c1cf8035c66b5",
-      "s": "0x4a811b18a6b442aba1b780d29f69516c9c0992f66c05ddd5f3f0f8eb7ea90304"
+      "v": 28,
+      "r": "0x9747a9db648c3618161ef20431bf6fb22850d5e5665ee20da701c8956e5d1390",
+      "s": "0x35e755ff1615790a9fc68a98c0c04fe45a80fea018c391aef3388e97f1c157f4"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Steakhouse-USDT-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDT-Morpho-Steakhouse-USDT-multisig.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf66ec25d288fb1c2ba929e2bd5c17d0e1d4fb5f674fd37cc6ce56362f81ab984",
+    "uid": "0x3ba1414c318906e2d5ed6fbec5c1866e04ee13e37a049de3eb7e36d173c0d72a",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xaeb428d0b8051001419ddb3e4ab087479eee71a9e222569aafc31cd6a55c490e",
-      "salt": "0x8f4ec6c374fcbd4d62f5dd589aecb6c4ad3f487543395c566c924b4999d6670a"
+      "data": "0xe79ab96793ba5816dddea57c7a40857cad2c687457b17ffa9e530b2133d840db",
+      "salt": "0x7435b04064874ac732f302063f7cfd06c49562ca1db023bbe8a5432c3ab29a69"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x7c4d7288345930b7c5640fef54236878d135a3a21e555ca0fb97ff8c3dbee4d7",
-      "s": "0x0443420c6709b007233722518abbd4b26960394ef872c3dc4b67c60a9fa350ed"
+      "v": 27,
+      "r": "0x178a225b0f84f2b0ee901b29a863f23749e9b45dc758c98fb26dd5f5e4267a1f",
+      "s": "0x2e0ab0925dc6aa51a5be05b7806d1936e4803e4edd7aec0c528ab5771152428c"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-USDe-Euler-Yield-USDE.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-USDe-Euler-Yield-USDE.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x65942ce68d9b7d920921309efee48fecc24d64dfe1ee3c7304c054ddf696cc41",
+    "uid": "0x997f5f38cfc179b01c694543832bb73ad0ba1f888b63abb7bfc667b1b6cc9009",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4bb6bd6c04243d74cce56a83e17fad0af3d21832d6084e6d6431a271c308e676",
-      "salt": "0x2c519675d362361f0855ac16f641bf9404077b6f2bebe4732607ef365a5d85ab"
+      "data": "0x1540d491a03f4b8461c4fd78c2d873da8f38dbc0992736d7a3022be2dbf0aa8d",
+      "salt": "0x60d770942d1076ea0c8543a202db2f857e73fe5cf3c116aa07192d1e05c0fd7f"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x430f7febfab80c606ae34bddf05bb61d304636a7fc4d87b7389f91f935065294",
-      "s": "0x4ab156fc73ca171b55c9296e635e8e6f607d9656b0259472052a3cd7614164ff"
+      "v": 28,
+      "r": "0xc2b31891b0f468044e4871512c97e77086baa8a6bf3781fbb3d38f8b2739eb68",
+      "s": "0x49b06ae26f225ebf90ed2660b71401ff83abd4cfc3097ca46c6ee397d65eca70"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-WBTC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-WBTC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xfa786b3176699c29932a9a109146ee918037e37cba1a904b20bbcfb16470ccc5",
+    "uid": "0x0abdd07fd3b8713299b85842ad2c62bdcfc483ce40855da1603aece3c958ffb9",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x79ae77cb217b75abdeba806f595bfc895c5306affa6f2f3c0fd18b8997ba2bf1",
-      "salt": "0x92b66bca50831bb75296c75d1dec9622c15088373dbd70be5529a8cbd38641d4"
+      "data": "0xd95b1b817f7c2cf5898621517dedc9a0ac98df2933f89f4b1619afa2ee9e4e45",
+      "salt": "0x9a09e95aed7434cef4a1ee3fde820ff42dd6369edfb17429a7210dc7e5d6efa7"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x7a9fadb128df30ed41baa95b09a7123411cf22b6575727355c942e0e1b9e187d",
-      "s": "0x692865beef1870d53eb31479e61696849bd125032bdd154d338ba772cfe9e022"
+      "r": "0xe92f61c17e14935517796a91341837fa232b62e32505b18478b7bb2fe3392b47",
+      "s": "0x6a9a0bed92acea427f142e34652816abdd5d0aabee3a8f0be2789ba256c412b3"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-WETH-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-WETH-Aave-v3.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xeb1ad6f555075b737f379aef30d81338f22189b2a517a163deefc4b95da2e2de",
+    "uid": "0x086dbe712bf57d7733c5e48f712ffc10aabde2d5ead9d58620ff26317812e5bf",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x59795d47e0d910ba8b8acb77f4580fe212f9f3c8c3a4811c4e0925f91179fccf",
-      "salt": "0x82bdc8a648f498bf7988252c890635d0d8481cc53efec669766c65f48f6afae5"
+      "data": "0x84a3ecbbae2e6c9e03810bd6403f971a84a831c49ea3b32e5e7542dff24d749b",
+      "salt": "0xb2ebd8855e4afdc9729590179fbf115626682e16f95861041f7362abc72419b1"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xa152127d9787767aadbea0ccad36563228a3a5cbbfd12009b80c778dc36671ff",
-      "s": "0x60d609bd4db698ca66f8dcc7ea1b618d39800b1123c7844a021e34365ada67e8"
+      "v": 28,
+      "r": "0x8a7d675f660fd4b9bda388d9bad9c507bc8295f2e11bade1162d0e4f4793d123",
+      "s": "0x613c4b61aff30d3084b759138e49918fabcb032642a697fe22740489b28a8685"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-WETH-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-WETH-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x354073dee3483121beca9d146570c8c6ff8863aa8c04b0e0883c51492d123d26",
+    "uid": "0x02a5d1fa687601cb4a410d59e67f66030d86d14ddb32df228dfe03343647145e",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x572d934b41989ddb14e1b8ff315e7253c1e881d5e4f0f4e70fce44372ae25a11",
-      "salt": "0xe6297018563c29bc21f84a56e40d8cd71ea99ef697e60e718158c7539b1cce9b"
+      "data": "0x4eded82ee1a7be6026c4e2450217ce9b5c295a928a5f647c82f5a9fdaa576738",
+      "salt": "0x503ec562c5ad5d16020505f8f7ce732ded2da71d2551224ef6013f14c3b423fe"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xef3bc331cb354c3cd778f3d08f899bca15f8c7457cba9e0b144ff2c37d211ed8",
-      "s": "0x29194a3d8bad8b0dead5c8f8349a062f323b03167c35a9563c28dda67d28d8f1"
+      "v": 27,
+      "r": "0x917c7987251d1355643c7d5cca691fbaee4e6be21012241757ffffc93e0df7c3",
+      "s": "0x090f58985c8788849409198516d157a98b3a1709949c7e8daa2a2aaa9bd23f32"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-WETH-Morpho-MEV-Capital.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-WETH-Morpho-MEV-Capital.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x0d3b1d0fdf073da90d79b32a97a2dfd05d64e2df815da3fd4a9ee3cc2b0a7739",
+    "uid": "0x8e9454356aee2ade85c892dee84bb8fbaa806cbea116cb326cdd763e0aaf7e15",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x9decf85f39eea6652c3d2d6def089f5f5977ff18d67ee05a0bfbbfb56e329096",
-      "salt": "0xfff2ee0f7d002d727caeee4f2423c7a41a1642fa2de10d4ec061c15a8ada7370"
+      "data": "0xbaf72b508091e44282782a1bb34b4b48c1b1ac1fab38b0d8041e8bdb6cebd344",
+      "salt": "0x6b4d441a7db3ad816bd4e44e61dde2ef8fa34739f621d065c63c9d496ada77d7"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x2b606dc839ebc60bac908737600b527f4be41d1f73a4600ff851c22dade0dc2b",
-      "s": "0x2836e22eb8ddea6a39ad68521a6b76411f2b3657b007a9440c401685e3ecb9f7"
+      "v": 27,
+      "r": "0x15499069ce0e676c709a616486403997fc4962d938f2a913e63b574f20d9672c",
+      "s": "0x409db9ce23b3d5e731ae04a15270e986a3831c01edd1b5f45a40d753708459d3"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/kiln/sigs/calldata-Vault-cbBTC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/kiln/sigs/calldata-Vault-cbBTC-Morpho-Gauntlet-Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x8d60ba0f419ea4637e60aaf71aa7a5b914ca3738ee8e356b7d4af0d88d36ea2c",
+    "uid": "0xf0c9ce0915d02fae970bccb9f71e6d71b94481ba95f9605bfa3e3ddc5dfc1dbf",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x422aee3a1c8225174115ecb24a99199faf5010db4718f6c6199eaa04e11bde2f",
-      "salt": "0xbb9b4ec6b4526b400975f4359d6d70c33a0b5f7e6154bb89bf080ea410301179"
+      "data": "0xf31222eaa229b96b1ff3d051d6ee64869acb026aec23cdd07571554df1b246f8",
+      "salt": "0xe5fb0e1a9f14e06ad7abc6fc8d8953620e17bd7943311b26b3f24a3d907dec10"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x685cd7ad22850fb431de29b94e55f726fb58f17f072b691bf6c9a5f6496bb444",
-      "s": "0x694dc2ddec466f062a80773f3af267942b081d330f21a99e0cf3f3ee73c99ef9"
+      "r": "0x33e0028b085c2568d2660524ff54c5be9dd5c08f65d577bafe85d3a31c96163c",
+      "s": "0x24b4ab351b8af33d4172c6c34fa45a6549f544d447aba7abc7fccf2721c75e09"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-9summits-9SETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-9summits-9SETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xfb600acd1154b7b9b7c947b5b41e8802f51230312b8edb331d96514b713ae693",
+    "uid": "0xd550e2832f0323c53810786c77802e711c912f770da990878fe15a26e83887ae",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x66f3e15ec8cd82e69e1f46d4f9b39fec52bfc375cf34a7b5002aa86d20e55903",
-      "salt": "0xe641acbe4a3a5fc7edecb39b1c260046d289bb470633e6d67add3e6f898bedd7"
+      "data": "0xe73962eeacf105f008016a667be8a06a5395f1dac258083f22a6a27ced269f2b",
+      "salt": "0xc45b8f8d8e76a657ed5809a689dc5c15546baaee3735cb3c410f62b06cbf24bd"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xf3b091d56bca5da9a02a328cfb049e1172aec7911dba664e4f1ddaeaeca23529",
-      "s": "0x5f8bd2dcdd82b632b453a6dda8c7482a16c763a1a8b48da0a6a3b94795f3331d"
+      "r": "0x098108439058534dbb3588355f05bd8a4a2833a08cc78982444bff6b89eaa49e",
+      "s": "0x5bd67a6ece7a797e2752632a8bdf1c0492e58b58338b62c3208cfda7394ec370"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-9summits-9SETHcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-9summits-9SETHcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x842502d73f6553db321fd8760f89f662389ff99c7cc28ac6a47fa7d6f5c9427f",
+    "uid": "0x874ab1b3fa284ac46246c5da78d224f7cf4da0e8aefed29578ce0c02259f7131",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x7aea84aece1ea02fe83feb6fbc73cee7933973f3ad8fa431e5d6f6df919302bc",
-      "salt": "0x4b324eafff16d2e6af24bc2a0c3dbad3345a1fa7061d19c6e382c687f2c2f719"
+      "data": "0xa08783b2588b8ff7cd76c7701953f5d50d2ed1dca1279584a260ff1f9ea56e7a",
+      "salt": "0x5f7701a43a44d516de938f95ff5c33f6ef38cd0b8f41ede8e5ad2b01c1e2fc7f"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xe02aed1d05b50b978f04aba8478d1cb458c418b59125693b5fbaf0f90d8afb80",
-      "s": "0x5b374279a285df2608b8e438d340d9595a4915703eca5f867b0c2b2b49cff105"
+      "r": "0xb7a203dc224ffbe38421d6e6024399e00ffbe692de77c9973e5a4d935952f992",
+      "s": "0x068333a4be4f8c316e62c77b75775e584dcb681aa6394709b5b0082c11083c41"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-9summits-9SUSDC11Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-9summits-9SUSDC11Core.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x251821578327cc54c105979dcfe9d98e509bf4a0c0eac25d998d7cbe5b19f09a",
+    "uid": "0x79a070cecafdba7ae2ce60c4484173a0418a3b7fe9a1e0ea33678a668ac5cf11",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x515a02a6465a99319e8fed800678576f5386b2ed6af86eb636cb869f5bbd8f24",
-      "salt": "0xfe38f479cc06408754b7b2a36820ee52fbd5f39ae2adbb6bc6c4de17f4171b7a"
+      "data": "0xf24e9ec9b0c03e1677a0c9396c38080f5fdbaf3aea8851de4c1af620ecc9a357",
+      "salt": "0x4d276f07f797e85275847359d9e56e6ecf83e20bdaed158fd36a9e2279d0f662"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x6dcf0f66d991e4b21ac8828814b68c07394f7207a9b1cfec5c833c5a7199414c",
-      "s": "0x4c857aa212d4991643e36b3bde44a8d5ea945e1391a53efdcf1092fe5c331597"
+      "v": 27,
+      "r": "0x2764ab094579cc472df34378bd0e4c7931a0530523bcd31c09cfa421fda63e35",
+      "s": "0x32be6d3ef177a126bbfadd8d6c65b71cb91d1fa35868741171c3f62a307539a7"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-9summits-9SUSDCcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-9summits-9SUSDCcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x004d146c18962fdb42054a095b5beabc84a166bc0918f16e24e74873e49185ad",
+    "uid": "0x2a5cc974b0739da498ac6b34bcedea5cc4e158f306d83833695c57d62319277d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4ef86f51a59d533db8a0ca7b702250bd344aae243cc701d4ea3efa277821335b",
-      "salt": "0x309afdc7476b9263bcb2df1489f075a2891ab93181679a2a748ec06c1da0dae8"
+      "data": "0xae79b18845571eaea0c781ece7994669c13a09cdcc4508cc669ee44748d968e2",
+      "salt": "0x7ccc3b4e96695ae8434b37dace7f2fc72ae38fc74dcfc46be9c8c0d2984dc7d7"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x3e1622b6df40cdb896a74d9d5a93315fa25b3ff6e5ee0ef6998e54c90dfe443f",
-      "s": "0x5f818a9688f69e48383a5cd76ab3e249bcdfd21d2240f1fe96c519de9cbaf74c"
+      "r": "0xaba293f2d0b37fe2072283e5566419310e3d22fcba0875f65ed33abf5d1ce124",
+      "s": "0x3c7f88ce4e1498fffa6851c08cce3cddbd7538f64ba848a4a29f40f7c60756c1"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-9summits-9SUSR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-9summits-9SUSR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x7bd7205409e4331e29d098e075b3235f5c0f0640f1d08a2b28f50cf617f26941",
+    "uid": "0xd8beecab71a0f700071a6eb454f09d5fdba0feb6a7b38266f29b682e3f0ad521",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4d380835c4e8c167740a292894877fa0946f5f33e11e229a850f3a3e880d55a6",
-      "salt": "0x40acfc318390aa1cb1ce9f9fc26d82e7e70928e35f6c273170bd9cda012f1a57"
+      "data": "0x579e136914f92a96e166ae9b9a58f392c9b35303fef643553d9787f2ea5a9333",
+      "salt": "0xda42b81c2dbca28deb1e0caf7b5b4d0617405d1c196058cdbb0bac42ebb5c7da"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x4ddaa3843172d5d180de49ceda516a5b11cbc3813db951d5cd0c93e5724c55c9",
-      "s": "0x29a5388688de1c062840575c67c99955e1a13afc83da063251cfb6bcef2b3c6b"
+      "r": "0x2148a40e0f63455509d08331193217f7d27149ed6ac4b338baea76e6f70695f3",
+      "s": "0x62aa0e97d1305f235bc67cca1da13a325d78cf86a0cf4d10317322d0070eec18"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-apostro-aprUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-apostro-aprUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x536a1ffdf41edc4571529120dba16c3385f3671253f20fe1c0d05ae70ba97785",
+    "uid": "0x3aeb6d997710852e9b0261faa6079ee0d8d2f5690d89da72239007382fb739ce",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x24a0076fe90068185f39dc03155106b069109975121cba28cfcbb76db2b48186",
-      "salt": "0x7ddf987951dabcaf917c5bb6b26ba4dca63775108a2e04503cb22c289d008a69"
+      "data": "0x5048954da4faeaeec7da74c4fa7d7080d6be553ac7239a22810a34693bb744d8",
+      "salt": "0xe223140fd8e5ed5cdb51fe36a2497fdd5a4d9f0d702087a97df5d419f43af191"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x31f07d1b53cd5a23e3b8a64a088922cb92bf7475a29b38ea3b755fb779d5d3fd",
-      "s": "0x790514d25204e841658dd680ef608ca21463890ed686d6995b4922d71fc4b3e4"
+      "v": 28,
+      "r": "0xbd44d47ccfe22981ddc40c5f0200e97c406b9efe9e8d1567fdb22582743a9b83",
+      "s": "0x19c4ff2bbff977e25b99d9af86da41d966a981b88dc2d1ddb9ffd1197ac97e56"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-apostro-aprUSR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-apostro-aprUSR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x2718828d777ee7a51f99391e67dc2286bf3dd347007ef614455fe9c36b52fd55",
+    "uid": "0xa03b730504fa08b39bd7a889981eecd8396b37479655201073641f81f2e670a2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x69a80ca2c7fb80efee332744366f015d2a9eca15e6e5677d2d849f924e83b27b",
-      "salt": "0x9d52cd529f5fc4b7dd1d869ee1b59e5477ce9fd495834116f8825ae37d58381b"
+      "data": "0xa00b11c925654980e836e0b752a33736ca54f058cdb86092930b06a8dc18df1d",
+      "salt": "0xd035354837c7b7b9143dc1298954f2a8dba7508ae8edf670a5700d052b5bc7bf"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x949788c5a3920430747c3b058cc1b04b6010c315c6fdabec0060c2c4fc31d189",
-      "s": "0x399a5e8e83efedf047a496d258b0e290cf7e20771772f5b9face4fad332d1eff"
+      "r": "0xf0c6b93727850f9a9d449d00e1438b242110aacf7dab877c5f5a7ea61be2aed1",
+      "s": "0x27825e7d6d9a5693075d584b9011b5b4fdd66b32033c4885c514acd50860496d"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-b_protocol-reETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-b_protocol-reETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3e339f96187faaff4fc7791598461c93c8ad5ef1b57a5bf15f8ccd2971aa1c65",
+    "uid": "0xfcfce4a5da906cf101efbcea7fce5950fea92ad5ad99d284e0c37be9cc1f70a7",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x56e64d9c02b88bf868382ee00b2c32168baffbdd9b2843649e544418e4495676",
-      "salt": "0xeafbe6a2340c11c0022a8cbf9510135fdea85afb91217b1216bc507b44b85366"
+      "data": "0x8da65ea31225a1e85093c2432e884778c8bf2b283ad35c78948954a5aadc3ded",
+      "salt": "0x600edac8619a1b81b8ddfee5e43448424d886752bc2792b99016a77e760a29ca"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xdab1216c3f5d1f5b53be1503fcec31afd30e24066370e4932d060ddebdc7d8bc",
-      "s": "0x0f47c75251c8a714710387f7540a2649c1dbc70af1cf875cca0756d762df83a4"
+      "r": "0x20078dc814ade897614a09daf18e3632dd6fb7544a1c53ae8e7cb5c1a7515f53",
+      "s": "0x1b9b79f31cbf751ae1258012d644b8819a1d778e2f60b5dfe27e1db154e2711a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-b_protocol-reGOLD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-b_protocol-reGOLD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3b1756841a83383044718d61fc7b04350f162d9c80221c6d4d780562035c4425",
+    "uid": "0xdd834e0ccc2b74ceb0c62f1e22422c7b44ac666ae167b0bc0e67aa536e0cba76",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x76f136e0590a35312c7e14d8f4131858f7887af75c294a83fe9292c7aab391d8",
-      "salt": "0x186d7285a27c212bc3c20566d9bcdc4071cbb10fffaf43e72981e0def9dfd978"
+      "data": "0xa6ac9318be45576b4f6e37bbc515c72c75ccdb76d4b4a7fe9321b9ef044956d2",
+      "salt": "0xe086080240e066800bc89f54a05f305cb0b7c872a5000c3da38e0c60eeb5a726"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x19bdd48d0fbe747fb79bdf1ffb86b5c4af1cb3787a406ff2526a8230aa0e50ee",
-      "s": "0x19e82805ab3f417c4fd41e485edca7ffa859a37ca5977feec42821a8774c104b"
+      "v": 28,
+      "r": "0xa201eab0c6e17b3d55434f9319bc9e1c864795ee572c43b35a8c4bca960c4508",
+      "s": "0x328c93d1e0f98b5b229b5f577c4e9b56a40110cb604fc342ddb5abce0fa4f89d"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-b_protocol-reUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-b_protocol-reUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x270e68e0ede4834a0eba9f7ffecaedea7db8cf2369916ee691c87c128146ce52",
+    "uid": "0xa6657ff9248aa743d319d4a67c5ae55a0bc4d9e9ddb35182b4991ce0fea2e1b2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xa6f7443179f74a5d9c907744020792013fdf504f2b519cb4811dc136f5c4e4c9",
-      "salt": "0x713ed7878ccc962a6258f7d9585bd11f13ae21c94d5f76918476b84598af5370"
+      "data": "0x7dd9bb184bda442404ffe3f6391e6f72db5d00dc7d21ee7499fd445aaf05fd23",
+      "salt": "0xea409c5cdc7bc4c14b91ce37011f8a3d1ff84517ceac32f7f0e8ccc5038c2dd7"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x292ff35eed3ac2a809b241fadcbe9ec787f49ec12b700137368cbb8f47f4449d",
-      "s": "0x18e20b57dc928103e18c4c5239753bd5c2090f0fe965e6119a61d5b3b42a31e8"
+      "v": 27,
+      "r": "0x7bed98b174f3804402afba4e3975303657fa9ee32c68ffbde95f54ac83c20ee4",
+      "s": "0x22ce6961b11fd891ae2c97c4d004514fe0ac16800fa5bb5aba375748e132dbf4"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-b_protocol-recbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-b_protocol-recbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x58aeedc13efe83cd87a53e7e6bbc32cb3013f7cdf9b6b12dd6e4436d15627535",
+    "uid": "0xd3675a4d99db4285082cf73aca257647700cf5ed59606d349dc8ec2d08be4083",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xb6aa62435170ee48a6792c7a7fb77c6d1396f4d929c3986cae3bffa8c32a7043",
-      "salt": "0xe58fe398e23ae9fbb82e699f99a49df5cf87a2da79759e92ed36935e1dff1dc1"
+      "data": "0x3d08b3f23a0828209e6a993f8dc62247400458cbcc561201fe81502d6cb20941",
+      "salt": "0x8e681c69bac06dcda03b6868d3135712121f3a3b8bff614b00baff72a87bb3fd"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xe9ebf947fd5a8c10541be49f0a8c1cecc30fd285cc12132ceda5468322efdf4a",
-      "s": "0x2023fa62a33d104bf3502f766600f53446509989b7d6ceb333a1f3f3ac71bfa6"
+      "r": "0x19c63ebaff4c5846b4676617badf1b6512576b46e752defc87bd6bdad995fa73",
+      "s": "0x7f7617295b5e0a676bd98e4725d6f400f27ac04e69af2945f627125e0ee1d02a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-bbETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-bbETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd0e0720e621861179b51ea05418aca50e9f6b3fa1ade71c0fccae5fe84577ea1",
+    "uid": "0xd78acc5070aa1932a4ec5f08f654b2d1e58e8c388d0bd69e334bb32af47e5afd",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xd9c7e26cc298428bd2a9e4c654c34888b7b55e2238100af5bc10cedaa0d608eb",
-      "salt": "0x8f9825854d860c97bb088f4abfaccfec1ec6590988ef1a2bfafd78e7d8c883e8"
+      "data": "0x03a7c93bbd897a8bdee29e721ac7ce97c578c9f419f612ee91799005b8fe923e",
+      "salt": "0x49f2c8047613cd191e0622b055e1abf4e3f215c2952c30d04f04cc8b3de109d2"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x09aa2dfb556ee9ad56800cd610c3019674d89eca8ba16052d186c68fe05c3bd1",
-      "s": "0x1a56bc49c4b57ad52a487118aa614c180bb370e41b34391b84d5a4012b2e8052"
+      "r": "0xd0c2b416cd9a7b5ea7eb6b278cc7a42a2c9e51fc04dd32f7745abd62a369b2d0",
+      "s": "0x0e1799a9436536866d5444a0691f4a91057e350e37d7703b3a73cd279601f897"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-bbUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-bbUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc5f040779a6cc9fac52d668e21853572860f5ee77dd78352341e7b2b9dcc15e8",
+    "uid": "0xe7a63b06c2bfe6b1ed717a444d8452bbe7002a80a44613fb75e97a508994685a",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xc324514a6ed5fadb5958e041d1a63042ce196ad571561d8ae7388eba32f36722",
-      "salt": "0x3d9cb19593aab6cbea6ad5c72f8f0006b8cf77591791765d5093f28f75930fc0"
+      "data": "0x587e796d04009a01eab3f6a4ceca2b3c2516e100582e745f2113a95afe9af951",
+      "salt": "0xd016cf0ddd2fc50b597d7df2eeaca0eb28e2f3711309cbe393992ebab85257d6"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xf38fe8e011c61132117048d520000a38db68fb2dbe5dc305506944699a76713c",
-      "s": "0x3157e01287953170327d95b45c45533e6743891a1e954bf67d4f7671d89f3bd7"
+      "r": "0xd8723fe47796a51d203259fde39b58c97a2022b8a00081b5bed7b1065d2180e6",
+      "s": "0x7c659a19c6645098fabb87e24697f2b030e910686646fbcfebbf4792246b2761"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-bbUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-bbUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x35cd1ae50b8471bf3d30af5cbb370b7d068b7440d31274540b190622b51f3897",
+    "uid": "0xd033e9fb1f8b6645aebc9840869ff5ae82891ece15c06f756127ee1afd7d6c3b",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x7a376588659e1d6e69d5394813a2af5aba71f6bfb3a818d8962afbb5f6b52358",
-      "salt": "0xad9e638cd4dde428ad2ad8e1211bad5b2c12967f119e1178cd0bcf23a36ae6a9"
+      "data": "0x8edf7ce192452810fc185e4067d031a471cf7db2632e80df365c490fc3266755",
+      "salt": "0x29805b43a3aeb5ac15152db0d534cabf4e0b02cc5ca1de7039453b7fd7bd0bc6"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xcdfca1b308fd0390367cce7a1cef19651898037c7247486a48ae0f4a27a33b6c",
-      "s": "0x4f8bebbc5db0f59348a87aaa23b9a2b75de36c5d4bb0acb3a346b31f443c85f9"
+      "r": "0x1b67e434479d52025ec65fcb560691d3c0117ca8b311ef0ec4a28249c9edcb22",
+      "s": "0x1772fb1c27cd25782eea7332d6227b7705f149882f9831aec1694d008c101e39"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-mwETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-mwETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xe636e590cd8a9fff3f8daa2b8f3884d748fa3792d604c3e1e78434a7d5429aac",
+    "uid": "0xf7c96144efa0112a6a6bb7205a77c86e438d6349fd8e5872e31640f92f7829ea",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x81f9a5f61b0b51b82a796018c6c62ff349ff998d00d6082e9b7a4555c30b3a68",
-      "salt": "0x5fbb5408066ce6ff196b9f090b82beb32741b7635604f2a2ee665aa6ea01792c"
+      "data": "0x4feef06af2c4e96d1aca6b263b94a5d1f2e5b9d3331d71f748df9500fd460cb0",
+      "salt": "0x3baea12685f87f9b3476fab0db06f477a73784f6751c14a82557d1c1d39cea1f"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xa7e94d9f801b125a9901c07f677ab1be85d78adf41068be82279fa6ad3a1001d",
-      "s": "0x586b515fea93489494155c70ed21b3c55712d0b7c1907f71ea33043c171d445d"
+      "v": 27,
+      "r": "0x5c68cde5714816482910b5eb9719b54c3d85c47b83957272b6f892f8f757b467",
+      "s": "0x3d0bb6dce9fde960f46f70bc5f4f133631c91560075efbcee3afda894d0a1afe"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-mwEURC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-mwEURC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd45d2868f92bd74e1c24e180eab44f9f072384d0eaa77a226a34c144251d3392",
+    "uid": "0x564084e5bf2aa7c4510f1a2de1aca90edc6e5945584461669ce5f69420cf5ea1",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfd8aefca598db38ea30455989708c5115a48e29bac835ea0b6cbffe31ce2f9c4",
-      "salt": "0xdc259d30ecc157ccd5b919d4710e193774fd50481f091177e3ab50e8818191b8"
+      "data": "0x74955bdf358b80ec1bea120290d16782aab016388f92304d4a2bf0a10fd88e8a",
+      "salt": "0x95baa4bb54349231374ab99657fde8f38dfed767dcc64bf7706384ff585675b4"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x7de47e85f7df41cf8f82c2d026a2bb04ae714375a13d830756994fb8f4782047",
-      "s": "0x2fa63bb3a4a2d88e2d5cb562a08eb79ecba7cc1439794feeb8b74287d4f11d66"
+      "r": "0xdac8417ed327b966cfb584794ff0549b25ba5fd63ee2b9b3c9e8165766e7c3a3",
+      "s": "0x5b7929dc429b6294d37a873ab26ee5c1a0878cd9909f5bb79fa0d6c5afb24ba2"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-mwUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-mwUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x87477bb64582b468a590270825dfa405145cc754ab0a0e4a2f313975477fe2c0",
+    "uid": "0x9d6fc12ba9e219ea0f6f997527e404370ee245d1c803ad339ea5a42aefd497ac",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe746d7f0d76942d014adf315393c46e9bb8b8268c888ac4d61f91e20bf5ed5a2",
-      "salt": "0xbe7a20a1f136c0dff3cda395a3e38197737e453add894743801ef27014973e95"
+      "data": "0x23f3ffe975b35c437c75ced5f10f457dc8cb8b4f3808ffb99216f10464dbd7d7",
+      "salt": "0x1e39fe7a942ee712221ad7a6b602737425a430d64bd9fab21629ac8c7b5440d2"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x32abda27ff628a56895594dc214c43165577c7c239c2830fdda43a377b057808",
-      "s": "0x2d3c2fbe0dab3c126b7682971f04699e6bd413604faed2f2011d3c5ef741849f"
+      "v": 28,
+      "r": "0xc961bcc391d2130f4a9adb45091c27eac083445ddae4d8cc73263cd6f34e3f09",
+      "s": "0x6215d66abeb5b8e07750f12a4285241a1a4791b91e8261893b979bf02ca5809b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-block_analitica-mwcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-block_analitica-mwcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x38c8ef63241f218118f69f43272d16a7a995b98a933d9fdee546bb749be2c4fe",
+    "uid": "0xe35cf4f81b00193f49856c7126f67b94712db7d31cf421a73eb4d81e5a822949",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x71398ec99886fc67d8d7e31c481f214e4ff3de669614d1aa318feb467dbe643e",
-      "salt": "0x8f6b05d4d48f059ebe62bcf95d4f8151d5173ba9dc7788c25cd125e959effa0b"
+      "data": "0xc423b987ed38f93c138d14c5d2d38738b255dc26541adcb71741be655697602b",
+      "salt": "0xd9d4a73198799fed34bbb4e808ffea68ecdb0b0021352ef74189ff793748b278"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x5923acb53a39e0e47012095d9c4c257d4247febb1d2c053ec14c9be28a6e1d6a",
-      "s": "0x214e6d0352ce6855c9a520e77369e47071163f81e09d87e432db1a9ec9968858"
+      "r": "0xd3e7c9fc78432836a4467a97e56a13d0cc28f7599eea722e56a16bf2ed0ebbc3",
+      "s": "0x3f524214e2f5c309181fa027d894572ada948c7b1e3fe4e0e719ca38d74a5265"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-fence-ERY.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-fence-ERY.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa797e8bdd4242508d403a382aad3804229578aa94fb3f653cc3bf9a90e300e3b",
+    "uid": "0x02a6696bb535377412c553cf171253a606ae06efe959a7ceb2e1d7c91a372310",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x87116b4c9295c94616d9aea8d2c46152998904aed084121b50db07660d8871e9",
-      "salt": "0xaeccc78a40d3772211c7ac3e93022a7f1de5dc624d440d73234353fe41408b2d"
+      "data": "0x5d3c5d199d17b24bfff8ab0c29c0751c0aca6d1621f656ab2305653cbc09b5a0",
+      "salt": "0xedc13cdb18b9c5a9dcf426eab542129193add72c4a30528b6920a799da118d6d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x1d8609ba97e610cf7a2bcbc6ab24c6c655e0850bddf8f6e628bd2e66b4e03331",
-      "s": "0x63603876599e66bb5bce7e7d68773c072fed30144338fdb6677b08e646408bc7"
+      "r": "0xd85a25e82dc29806d641edf5a2716ef1aad8aa1d950562895ae37fdbcc8e8c42",
+      "s": "0x5a87b1cc202dfcb6eb8c52a7fb51ab30c612dd8d27b36aebf2f28a4d159e70bc"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-elixirUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-elixirUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x85f33deaa12ef995bd4cc5817853e25d912bb3cfb65449ee8e84845b7071b77e",
+    "uid": "0xb2b37f6a88db17232cf69322a996337df8677fe7601e7ebe934ad4b93d0045e8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x2ffbb0904262a1e90eed6ef6cd2711dc8a1e7d54273ab808f23f916713fb81d1",
-      "salt": "0x2aa1e3422af52e9d8d3921af3f9f23013d3e4dd899473562c11f03fa57f56936"
+      "data": "0x39ea8221864970f1af3beffa96b877cde8252a4a4215e0b4168626de5e9a2b1e",
+      "salt": "0x991a38a69624871a19eec350f0e47b956eb8742141c911740f9f1092ae27bae6"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x151111e0b845e973e62c346af7acd3f8fa7ea8860679ab12963ed1ea69e6cba2",
-      "s": "0x08dcc7ffc0af1a669246c5f815709a4806c52aaad832d251f74dea29f899b5a1"
+      "v": 27,
+      "r": "0xed236d5c36e8ae6c4990a066a4fd925e5cfe3c49655a9fd0088d9330a05b18d5",
+      "s": "0x285d6e7cf036223d9fd63ae54c55d195aa59f19ec5e5b808c8e33ce1e319199c"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtAUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtAUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x4525256c519f1ca655727509cf46f8a04be3a3b7ff390f6aa95a856124fe0437",
+    "uid": "0x233772aeaa9233cc5d1242e63391ac34bb569c61be6f7b39be0cc29d2d85a9b1",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xb99a08256800ad469393f6d1f0c1107cc59dbb9d21514db9266a4db1eb3af68e",
-      "salt": "0x57d37149cd3c56fb53b5ec0fa502f6ef8c9d78b98ca69b9f2184c3dbb71b4ba9"
+      "data": "0x5be928bfd3d0494b04be93db390367e338c044f33c5a9c4361f334aa5a69154c",
+      "salt": "0x6f8665a3d2431c7b34a1b49ecfeae40e5bf064fd57f0afadd1ef434d208044c4"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x234ce8ad1b7418bb2e005678432a63f60bfedf9b78d6490873d13ceb19d41efe",
-      "s": "0x543a973e31994a417dabd245ea1ad8428659f4109a7020895e4d41512a95a6e9"
+      "r": "0x30c5c6a58f5e2c2057534afbabf2d47222aef8bb76c8085a69a097cad82e4926",
+      "s": "0x3565babb8824d91701bb11aa5ec85e659e467eb3e13158f8f81b952f71adb7de"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtDAIcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtDAIcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc827c0e78d11836005f858368e2b3793ccc7738df60a08911d2a4eaeb861a910",
+    "uid": "0x7f97d52833712b42f02d1f1e896af24321f67b947a5d57aaa50af56958ae7d9b",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xdd5b731092c6fdebcafd6cbf4a9dc6f3987eab2447c8272c97292de098926beb",
-      "salt": "0xae9ce7c9c0b106f364a8eaf8845ee29600b3f0197bad3fee8de589e27b25b644"
+      "data": "0xa111b76bba628792bf6f51fa78b5cb9f07cddc678cda01919def32878596a1cd",
+      "salt": "0xc64a341513ccf9a500cf8a2db44277ac80bb9d88ba8381f408045675ecbc8f49"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xa9d2d2e1cf5914a34d86da7c5df81722bbf23e9bad5e6bf1976d69dcf78fd8dd",
-      "s": "0x1c4b6bac66359f0190991f9b1931ed1458357a94705064ddc7979e147cdfe4c8"
+      "r": "0xde339f2ce8f4bfe0130a37bb3728b530fd2b7e40791f6dabb27913ec05118648",
+      "s": "0x6d91bf072d4cc278ef7ed19f7dd001d3c203299613d01f3cf74d185848411172"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtEURCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtEURCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc71f6c7d476d6bc233548da7b6c6914f9f6d27868e66f2197523aec444a684e6",
+    "uid": "0x7f32e03e2117a070a277a041b1dc4d1220451ed3d3bbae2a31744cfa9258774d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xc683ca2da1701dac9e1dbee424e150921c192aad0e465f5ebc372e4869b9944c",
-      "salt": "0x044dfdd7fcac42f66f749a92729c784c54406d8a9a7ec317a1a86df8b31d3d45"
+      "data": "0xa3fe12bfdc0f7ecd026fce500e0506782b2ab68e7f192c576260b95fff9e09be",
+      "salt": "0x0a1ff47fe1c4e1afd39b60afbfa89c05472a72b073b7d0e17a0355f97344edff"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x3172e0e9bce1fa7431732259eaa9cddf968d00a07baf70e26646d3a04de942f0",
-      "s": "0x51d167738e306301261b8650e1bc768e708d4649aeaead0328daf23616cd5edb"
+      "v": 28,
+      "r": "0x8016a7090a3f4858fbb300ff99a12ed62c33506b2c464dc38a3083c1260c165c",
+      "s": "0x0bc0d623ca3072b2db19c9c8e7ad1541f829f11a982b8e44996e427157aa3cac"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtLBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtLBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x933b4dc96927eaf5b305e768ecc2272e4b08c4184988470fc561fc5c38ed1396",
+    "uid": "0x849d697a73e4d0e2c585afe07615f6d83eef52293242d684de7f30a78e9ecc74",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x806f628f60f390d9b0b244543bcebf71862ade741f039380621eafcac0368d2d",
-      "salt": "0xb2a63c96bf3aa77f89c043262e7e22da86b4cce84642b9034ef5e3f903017323"
+      "data": "0x17c85ba7c9a0ce94ab29629955cd5563deafe2765040739acc9486d9785b3b17",
+      "salt": "0xc0dc77cc77177c75619b8684f74e68a2a9c25850fede8b33ec98028863a5d5fb"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x6025379b8d22d81245b834df7b696a19af679a378270d0309979dedba5b364aa",
-      "s": "0x14081a4ae9971032780ddac982f22492ee68e734a94a37a89acea39a2c184048"
+      "r": "0xda4ce8f3c7238cdbd5a5f71965a1c75c0671d41328b91a852052a28349997da5",
+      "s": "0x10ac9238edbf9cf0cc2acf71b5a5406ff982360e6b38dd9a7941d76135d82983"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtLRTcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtLRTcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc3260a8eb3e917a0a76cb57730ed5e0f3ca0214390a898cb5600fa7d7f3d211d",
+    "uid": "0xbdc7c6b4ad1bc0786c88a14ad2b3dc2164bfd0cf2cc622c99e9992bfdc35237a",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x60208dcfed5a13f96d5c8f0c4950ee4e508200124e558e7255f7a853317c12a9",
-      "salt": "0xaf67fc1ad77c51029c3ead5bdc36587cabdcc4e4be633d6bbff483a9ca664188"
+      "data": "0xf78f009510a1c1bbc42374b5b24847332486e570858e2f5c874e627ef65443b1",
+      "salt": "0x74a4fdaaf3a7811d2e3daf9d2afede769edb8132c810003a468bce61c703748f"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x0afc30f831c029fa75a3d16bf71519f4c325f4644bc82de29aabb7c62c40c4b9",
-      "s": "0x2008a6e88fd09e8621375aac390a19839febd2ffa88d7a71f64e22fb6f503307"
+      "r": "0x29a2e573826f5bfb24e806766e1ed3010fc9988f27bb1602f638ee83d2651b6b",
+      "s": "0x2473fea918af6f6d520a633971dc127c4ac333149235b43ffd5140e2a2f50eab"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDAcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDAcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xdcf2c3246e96184f593f9dd4c212931d6e8925dd7f61da1353ba7b1f79096e36",
+    "uid": "0x339231bd866e251d8ab3a6a1babaf10e22f45dfb79ced6a6abd50f1cef89f270",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x99853140aec25b325749f5b97345a68b084af4808049f1a279d942e1cf4bb9b6",
-      "salt": "0x808e3012543fd00d3635fcbd30954845f51e92a6bb6907c579df9f3746299aac"
+      "data": "0xf6a528d80e49ee8327a07a6aca689f6afc9bca6d46d11177363fe1f460a79371",
+      "salt": "0x0bcf541cb643aefcd8077185c1433e9cbbc1a5b07c738cb028230968b39f391d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xb0d5352661b4a99a9e7bf7965e1262e07faa47f0c302ad9e812123d63e526410",
-      "s": "0x72bb76f8cc7498157cffcfa12d6fdb237018d1038cbb74d14647c086b05fc420"
+      "r": "0x788a7fce3aef9b27e2d637c3b5fb63b3231ae44a644b7b4bfccc34883e4eac3d",
+      "s": "0x3bc67479e8eaf7312936fbe2e2d1ce6064d5a0aaeaf05305edf8d1e31488f615"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x845a01f8675d15ed074b982d96a93e4462ebf3fa98695cc48a5922ce9b225a5c",
+    "uid": "0x99049be8ebbf85b4333da3b5e9f829e79744006f14d96c9393acb62a69d526a8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfdb1b4d0682e66ec288c7f2772b7b62d966e774d6b74014215662ef334d472a7",
-      "salt": "0x43f19ffa1a828a7044e3d3b4d0121a9339e04407ecc54bc49e0068a3a774ab76"
+      "data": "0x0a13fe9a601fc7aed96784403d3936f147bb6496d49b17e1a0541fa353117d93",
+      "salt": "0x016a88d969b65fbd40d2224e7149e83cf0925679c5a4997e0985a5e8a69b0a58"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xbd7cea0d8e9ae4c41d02c7761457cf3626f8ab3c547d7a9801f7059fe898bf34",
-      "s": "0x3e3109caf64e63cf36d3b8e9ba58771d7d5d0df656f2bc8a80e32660604ecbbf"
+      "v": 27,
+      "r": "0x4cf592388bbfb16237ec6f6d66afdf9e7c1ec31d9aa8a5c9a54f4ccef0894d2a",
+      "s": "0x0dac152d6944e99eb6e5e270761799c66672673ebcae2a55ed1fe60719ee4bfc"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x4eadc9feafd42e5f994725985a9c6f34d2903be9710ab34cfc2ae1bdac8c3df2",
+    "uid": "0x2625f174afadfdff99200e8b615cc615be123e17733b84c8e6a2b3f287d517c2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x7347a89b7fce1f83145161017958e96b70724a261951526d10d01920e34bb520",
-      "salt": "0x89639ba77b671fa30f77f5b04366bb4555a1f2935e8ea490838ec1cb6d29e34e"
+      "data": "0x8cd143461ff273da0df1f4c420887fb5afb4e7c297d7ce322608a22290a7d04a",
+      "salt": "0xeff680f2f705109bfd3c46e9b402e54c6a11a8c0cf5aa1707f54dca35a164292"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x63cb36052044f011715ebb17f76bc586cf4a3ad5685aae314c567ae914a1251c",
-      "s": "0x75830f1e8292d1d80ee7a357a9d44e0a0d0557724dded1f7d9b5bed1d2d9f27b"
+      "r": "0xe0176ffed11723d0c802d05679e4948a521f5c190310480d4658b1dcdd8be4f3",
+      "s": "0x58920b8570397be38d01e44ef24d6776e1d2c88205ebc1b08e1afbb4b0b874bb"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDCcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDCcore.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xae9ba5730616902bee2016fc320cdc29a7c71b7fe1b6381a36674a32d2c43456",
+    "uid": "0xa268279afced7b63394389513bd13531e1befea3eeb80c41e7c214b855e2eee9",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xedf362be07123dc3488b798c5b801d459f924615fd47897b29ed4d15da93a064",
-      "salt": "0xd6d833fe59e51ec9bef6aaeafb8863b0c2aa108df1a81fa7bb2ea771bee51723"
+      "data": "0xfe00b1a352141a5c0366c8418af5b4c118ee518c0f386530a3629f823ba55ac5",
+      "salt": "0xe3bf7c26ca42da2bd229006f581b09dcc4fe94ee16948879189cc07ebebf203d"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xd8a278c8ca99d5c0431118c7913beaa36e54dcf217cdeaedfd5f1a28d105c1c4",
-      "s": "0x1a2eedd51e88fd9de73f7a14b117309ca2a829fb6fc1395ec4dc4d112b521026"
+      "v": 28,
+      "r": "0xdcdb92931f443900e08a2b20e0e7e86a1209650cd09008dbdcd9442f16cb8902",
+      "s": "0x63c2aa230284d1a5d293e2b4225ced21242bf31c22e24aa1bd2ab52b2aa4f7cb"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDCmkr.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDCmkr.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xec34f4f4c53a049b5bd208adeb94351a28e6b74021869920e6e3176096ab5dbd",
+    "uid": "0x5f3e4fadfb7584619168f989c99cc854df9c69e45319394e4c037e3b5e2865aa",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x67ae41bd94f58ecdfd4d1be2f93b78a64e03228f5eca02383d3bc92b2a874043",
-      "salt": "0xbd28799e48745f5ea122800892f1ae5174bf583ba0b73e4499e37cbe6a4b3231"
+      "data": "0x5c027fad7c131c56672786a4fb939723a59732bed46478c8d206070c48af123c",
+      "salt": "0x4511ab9ea2824d11ce69dae457386b49e7545ac50fd35b32bef6a3f327ac3e0c"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x065153d33c769da27b0879fd8f08a3bc182610fff490c88434dfa6d60821c22d",
-      "s": "0x295ca9637c4d65a6131508d559ee6308256d900a52073e293b276b87a28171de"
+      "r": "0x4f2aafda038f138c5803a30b726029df6f2b10489d3e984ef2f89e320a7f1602",
+      "s": "0x7c856ebf990bdc7371c65b0d7ba15bd0b47df97dc9bb77e198571dada37eeca9"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDCp.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDCp.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xedc8f8e987b7ab8ea038df94ae4d5486151bff37e70d53702b030659031be349",
+    "uid": "0x71b6ebaf07f282d53496f56dd4f0d7d0c375a4d8a7d359c391e7af424b10c092",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6af64e60cf18c0679cf31d267b8c43f340076bd746c746cf2bf09932e9b4de55",
-      "salt": "0x33c4b225aa38b17201548909a08e14eec52d4127c847cf401a3fb0326623d345"
+      "data": "0x3477cf2c2635ab84bdd21db292c442e9c1fc49793edd71364a4d3e53ba884ca8",
+      "salt": "0x8b7792343afabea1293100244075eaf2857c4a8c63c04969a692287f7c076bf3"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x709275983e026db3b8a86be8e2f6f1a197a8d880ed3c55369e5b0b99450de438",
-      "s": "0x678498f6ee8ea751a6b66c89c884119e3e23612b03691fcf69dd8860c9c61ef3"
+      "r": "0x291f634abcda01a9df84978f46825340a5603b422dadfb0463fc5ee146736f25",
+      "s": "0x05f6f381871ac5bad13dee7e8c23707d52da4837801ef63d176ee410ff34241a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x04078178b695fd31cf10821c8b6d605691c59fecbc38e638b27c4720de224477",
+    "uid": "0x87b4227e3237db158150a75591409009c9cd3fc3090b1a83e939b2a406985ab4",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe97beca05dea230bbe1ca57941c08f39498e93ee66e6ce4bb5fa06ef5b394332",
-      "salt": "0x8bf9dc99d110caf4dab9bf55e37dd0b4f229cd9c36c63068696c3510fd175f7c"
+      "data": "0xd7467f6fe17fbbdf58f71bc7b64724b17259ec2e32419c0855a5629c5e5385a4",
+      "salt": "0x7574864dc4ecfd5158ad10ce51e1c3b065e0eaa359e025d1a36527237cf85042"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x93fca78e2845c2537d901d8dec6b6f4de2c67e33c94d53d4b65022ae585cc17b",
-      "s": "0x0b39f6e719af6920df4c3efd3fe06d4f34efbb383cff92e4441c561914771424"
+      "r": "0xd34eec0451f77f8c38ffcda85429606d4ba07e8915344baacb6f57ca2298d1fe",
+      "s": "0x67011d39b38a346b11bb30bae9c29b1e4908d6f7fcce243fee31663f70ee93b8"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtWBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtWBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xe5b1a971d0698e4660464463dc9100580fac5e4beb0ed3c7a4e59cc73daf94a7",
+    "uid": "0xbb7055a761ef6e610e680f939138a11c7465e36e44c52e7ae0a3dc57aa2970ce",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xb916f114f2bf57299f9272783aa2ea9c2a61eff7c865db09a15a434bfe12ac89",
-      "salt": "0xbb234662bf4dd73f184c57add64a0beea3193262c16f438519a94d7a1b33f6d0"
+      "data": "0xf7781db8606ddc2c2d707fec350c72f56c8e2f3df90c92b3e96f9f23f70f2040",
+      "salt": "0x206ae366a4d7e20e6c99c6f1d986407ba4a3b46b4b1671a3f0194bbc078ca077"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x80907cb72b299ca3c737027318c49b990f231bc2a976fbd784b799595c709782",
-      "s": "0x5ffdfd9a30e892c606f0f0dfd150d644dd005f472c2eb2984bd9ae94b14bc58c"
+      "v": 27,
+      "r": "0x0d72c7e09fd983f5dbc09e3f44e6af0b73db913b51d7597fcce2589702d94c0a",
+      "s": "0x49c658c0fb304e6fc1db7dbe64cb7c1f5ddea6fbb5e93dae8585667b91779091"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3000152161ab65844feb79419fd8f86a243aec79d55feada600ec8af29c94afc",
+    "uid": "0x23ae9e4ce0bc12c49813fb9d1a2a98a24e3fb7fcb6bf86625044980d868967c3",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6081f340c4f782d79901f2d4f91b32192f988ea0630f9a8d1e4e0737f175adb7",
-      "salt": "0x68fb709870b81f2958d819e1f8d379ddb4e33faeb47934635c0ed0a8ddc385bb"
+      "data": "0xa344cb242e34742da74a2ddeb5d8bf9fcb4a92f19b641d9252a653ef9a9a9bba",
+      "salt": "0x06ce87cc1d06893b1176123dc89e1a8b439126c4b0f11da345c7e7630eeba599"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x298c1d404f950576a5e324cfed38babf3488403c646ee333c31f21ee16981a75",
-      "s": "0x278caf4b12d115f0e21a74e8ba865cce9c046b8d1d43d970e013794e73b366c2"
+      "r": "0xc90863f4e41dd3302f0448e39f6967ad35ea5a3c0eab046bf58dd1e170a46a81",
+      "s": "0x6c9ba982b0fbf962c6ca7661190dd3062bc2278474b58fbf6b9dbcca587b481e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtWETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtWETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf6657847c8164b10f7e72915ec412a7d469bbf28dcb36f1cda8383f5856bb844",
+    "uid": "0x07a7290254ef9622ac63122116730bc82d7c943e743ffd0081f8d8612a2bbb36",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x19c8551780f8b04d9fe40ef2caae04f149b2cd925e8cf3109e4c44070623d2da",
-      "salt": "0xcab29b388b31a4f07548acf9337922da637be330c54484924cf8057d4a6aab44"
+      "data": "0x102d683cb92fdecc124a50968c7678589d7d17a1a36da657c008b4d3634d31d6",
+      "salt": "0x668b65bdbefcf4e169e4a99f8e03bbc7da36481b072195c8056825f0fb8d2bc7"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xc94bace8e435b8c64f40156e54b8be4a98acdb075cdc50bf3c3fc8ce0bc1c791",
-      "s": "0x02e9431fdea4e0fe9ede86c0543e4e17a0c6643cd4cbf124b869373e27bfc2e8"
+      "v": 28,
+      "r": "0xd88057537515709ae1e1eab7d4ed2af02da046c0da2df9a643c584ea7fde5f12",
+      "s": "0x355f1f927e241e17b7f412d07433807888e138cb05385ec0971b47b046c8694b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtWETHe.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtWETHe.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x2d265bb2c6c2ca364d6feebbdb0606d8d9c008d23877076a86b6c8da0466d6fd",
+    "uid": "0x258ef2cbbcd3f67dc6361f217280573bfe7cb9a4a3f694bfa84fa8ac0a49896f",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xdaac3a34fce455b37bfe8318f1a0712dce45fc62e8a6905a5c46ab4732f1e6e8",
-      "salt": "0x15f1be8a151890d13fbb3e59cbdc80711b61be9e18784d3ac72019141290c088"
+      "data": "0xadd7ce3674fc3a4c8298d158f9e6ab6a422241e9c52cf9087b3ad6ca19f00879",
+      "salt": "0x8b4d5c8a39182d02785d75f31c3e22ba461bf5d778b81cc1c16e6830b10a74e9"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x80f757f2d89cd69a4983a70d9023d04cf920266f970e70aee14d128d3fb1e1f2",
-      "s": "0x4c6cea15530db5664c3316392456a6c35f6eb1322777d15c9d83a4b906abe7c0"
+      "v": 28,
+      "r": "0x0212b69167a68f52a998b6d189eb785c776430004260cbad2768e00fea183c99",
+      "s": "0x72b3eb16dd78d9ebf169bc42cd159d1fe47dc0f70ddfbf2ac0d0f9a36846e44a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtcbBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtcbBTCc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x56f4e5d176519f893852269b0c0ecd2d4126e6067a0d4b0ddca446c74644153b",
+    "uid": "0x118a5d3131acb06a979f90202f92567066f37fc9b0919eb325f0445ba5919f4d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xffb1f25fe9e588523aae85a508c495097c43b7c65a6697a248deac1f0b34a2c1",
-      "salt": "0x6a941fc12effb660d4eb578a8e6a8605559540574ff79f07728fd9e81c25657d"
+      "data": "0xa029f2db1eb892d721d63fb6559e301d9ec2a652c6d12099b4c429f41ced35c6",
+      "salt": "0xe92a2e9de3ab82ce315164f5974d1c8617194515d52f605934ba6228a27b1e1b"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xae6cc573adf9f1c1b92da4df39aead9345df5f1614b50d08add6a513f470706a",
-      "s": "0x06a0bdc068449bc19d3b61c89e8b426579dcb0ff0bf6d9b4ef303bbfba1fe151"
+      "v": 28,
+      "r": "0x2fc38fab140ba74f98128b93902c39ea5ec95327a28d1ec532036bfe67ee69f9",
+      "s": "0x6f56dfde386ecd6ff83ad9c1bdaa269bd05cf7baae97dafe8cb15ca8bfe13dba"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gteUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gteUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xdb75c2f0b11c269450329fad021e4c7217cfeb8dadae56f676550bfc24819a5e",
+    "uid": "0xf7a2b14733ea70c3576df1b0526351228209f0d2d239b1a6761e4a160359d358",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xf0408769c3adacb2d2d1ebaa7744be2b21666dc4eb3a568d0065384c779dbf35",
-      "salt": "0x9aec16d0fccebee83c34a313551f89a205679d81fd1dcaf04453127111058213"
+      "data": "0x8bcccf31bcd4b4cf1a7788510e5468e659112d4df373c38dadee287eeaefd7f2",
+      "salt": "0x4bfa42c5247f6d0001bd5e480977a1be12d26592e1290d0c896cc98dda35cf30"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x8f362fcc96007c3a642ae1f16bf4b666a8915f748a0e22e884a7d08e67020870",
-      "s": "0x707eb415772ac9493787881cbc6a727283e7c8ae5b841a3123a8b3c8de45e599"
+      "r": "0xcb9bdc34f57bb3245355d652cc0f3fac15db33f5169b967f19a1c9ce1bba88ef",
+      "s": "0x7d0bce64ac10df6259d8eb0b11095c30011cb073481097798ed7d4f47379ba12"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtmsETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtmsETHc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x0e9d11ee53dbd9ea41273013ddf3c3173f9415364929109357b95be7f8b4f30d",
+    "uid": "0x8d9d3b331066b5ecf9da80d4c5e4886d55f3a2b9f3f9eb6dac21d10227a81b56",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x4936f67d2507a7b0a3f29e24e2a91c4b6304fb9e382869c1c3963d279c0c4da4",
-      "salt": "0xd2e3c290ca52764effd8ada248696d18f10c4719ea6cebb52c473f142147a027"
+      "data": "0x339b0a286b833ba920c58f65b7724fb3a840e754ddfdb5166e76267dc1f157e9",
+      "salt": "0x91df4b97b1ef76d8780c71b098976d29d9fc4e7802a2fa5193a871c2c9ebaeb9"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xdb485a04b9673647babfaf0d6ddba53451120c80d6afdfec92b5c90c7c4cf4b6",
-      "s": "0x4008fb1b3b202c45322e781f6d6e44dca5afa2df88d140ff3b19fa51e805f715"
+      "v": 28,
+      "r": "0xe86651fb9823485aa5a233beb7e0fdccdbd77e3c2cce3ca4ec03a9f767ea754b",
+      "s": "0x31993cfc2d040ef030025869c770f0e8718adf3a2b328561f6bbb8816c9dcdfa"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtmsUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtmsUSDc.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xe5ec7e99f21abdfbd710befcba2faee2acea11f4996cf774b9c01bc8f5b18c8c",
+    "uid": "0xd7ab22c0505179737eb141fc49c481f1db332e42ae026cd96d1177e0c18d95b4",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x961deb29cab2153f96498d3be5dee822f35b0e251c88802354bbc20060c07cbb",
-      "salt": "0xde08befe9139799a5e699511b687fb0f140a5fb123a9cdffff99802fcf0e709f"
+      "data": "0x0e2a5bb8147cafce6e2d5661d678e37f85bcdf7ff908276c3751e182545658c5",
+      "salt": "0x5a81ac61401c19f7c0174f3b8e400d87b178a94688f7b1879351aae5618bd05d"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x628555216db6da83cb59fa5ddca39fcdf3dad65468116634ba054ff40131a953",
-      "s": "0x0e97ee1364e59b593c9064aa7c2c3c270fe5e5575691e425ff3cf96422965d4c"
+      "r": "0x018bfd1f18aff9feb70ef9b2d3aca0d88151f3c969ff3a46a99eb61e6b0f194a",
+      "s": "0x490dbd70f181d4edade3dd1137f87306d6621fa8000e1dd82f297424857ad928"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-gtusdcf.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-gtusdcf.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x934ec25f29a7c6ad810ce7ed3e61ae18fe90cb24027a497289e6b681321f4b1a",
+    "uid": "0xe8a9284432d1e9bd40255fd63b52d5c5ee4bbb15b1b263a6b650aec5c36d3082",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xbb5f9a91d7bd88568f68f53a86f4a155df914340c7c1f7f2c8da03d5eaa4a7d2",
-      "salt": "0x2fb61d73557a91b2c94d3ef41e115f1e727b7afe6c8aeb39d0b13cdb5231d55e"
+      "data": "0x8cad03121a716c806d630606bd8e4483d47015722a158e4f4dc73bc37d6dc6c2",
+      "salt": "0x2043ea763a7254f5f887d7c69ee99be746ab2d108aba9e570475a17b52c5cce5"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x6d2d08a92e81a5ded4c09f1d551db31ed9968826a6003c02308ced236756cd4d",
-      "s": "0x058467f48216d3b44d425d4f42c11f99794a92d7b06e910e2824764470c9d569"
+      "r": "0x94ddc079fc309ffff673df127a193e26405c197b17b4d413e8c48df3a7a5cb99",
+      "s": "0x3bd42826aa1c29b7f626450f59ffc4df6dc3fe1aca8e0818e6059d68a6885516"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-ionicUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-ionicUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb2404001868f16bc367578e41c3f95cd77e652bd9b169c1a964718a3f594092f",
+    "uid": "0xa2a3cc8e287a69dc8ebbf5edade77f75f7c418c2e20c0d75463e0d39cd62c1ec",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x3bfb8a8eaa42df489d66d9244d8e9981cf9c949e318656d20bd47a665e9116a0",
-      "salt": "0xe19e8290774ba66b37c8244cf5e02958f2f2d5ecc8ad632723d464928584516c"
+      "data": "0x09834acd9e101762310d609a79a6c6dbfe45b551657ff2196d7d0cbc5f33ec46",
+      "salt": "0x4ee13a981c523a5c630eea7ab84865badd815d1feac4f0f93c940397bbc53603"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x31bc70edd3c1a8b66aba07cb8799fe462e5cc0975a16bca82259b76af198dd08",
-      "s": "0x5b61469008c25003dd2df1779e3fc5827df3f194ae96135f81905735e83a50f3"
+      "r": "0x7d88586420b21fa2ceb8f76505f07cd139ccad9551c74fa1444a28af50f6e770",
+      "s": "0x1e2b7e4fec34cb9aa0b932ebfd6a564de27a464f6247f42bebfb1a6ee227ce52"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-ionicWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-ionicWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xcdf3d1f2d18b818d267fc855adb1c5225ccd17ad07758a8b9de226b9e443eb7a",
+    "uid": "0xcee602f8222a7c57dd6b7667d07e274b20e983fa07cc533f0e6fdb3b756d74ca",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xda20358b1ccea6d91818e1975c858a41a01f3cd200a20a96bcc1118c2f7e0bb4",
-      "salt": "0x0f2da6bc4a34eaa0c6f8b328a88c99481729677fdf1d5f51198696a49811d4a7"
+      "data": "0xb900ca409a6d18f0765272f8629d33c1c1b35c443e8abf1703806673cce439ac",
+      "salt": "0x4af99f43766aca2a5d302115f97530668eacdbc7fdb40f905178427fded70827"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x7bcf97874460c850e28a0e0d32f2f575f7c094249a69478b72ddc7a7e27c801f",
-      "s": "0x6ee393d4ba69af5d51b34b50f594561da34a8205725d55904b0b64a4d226742a"
+      "r": "0xa780ddb957093aeeea88fadd0c4e7e2d12582df3ee0f97ba4401ab39f9254c68",
+      "s": "0x5b8081bbc0d9da0f9743c8a48f0544f7e83fe579382222cc12922c4e30c437ca"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-mhyETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-mhyETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xed89c4c79b3895da7119c8cdfe96685f089b581384d3d889e145ea9aebcc44bf",
+    "uid": "0xd42e64d51f4ca23b190d738ca92fdc78377d60876f080c88f37cc07e8f5e2601",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x3081055605faab1c37da807fde3ebf238048d37c3606864178c9bfcfbe58f108",
-      "salt": "0xd1b82eae7a656e24f955a72ecab888faeed906248b9cc81cad685d4d4dd71677"
+      "data": "0x7b1d6dfd391185d2dc029f3a81aada5163d2e58eb6ff4f3efead0e6eee58f10e",
+      "salt": "0xfb6f8a9f9103c0068b75820262946dc0d8907d5e53403ac0479b3e208459b5d1"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xfcd5b52dec11936a8bbfa3c2442f5505a5c505de25d68617b9564ead3f1dbf30",
-      "s": "0x791cfdd5d9bbba920da0903d78bb9a610990b0258c9e630f51b0d5f7ce909b38"
+      "v": 27,
+      "r": "0x95b174601ddd3f6a71973229aa425f6532f58cfb3b9db3ea210a0e3cb2625e80",
+      "s": "0x5f39f1941cc5ccd1dec8099c66b74e1ea3c896702c2c9a981eff69debfc412e7"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-midasUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-midasUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xeefa2a160cb0e8f6fddabe63a0bb8af67a79b4c839acf26959d02bbb77a0d910",
+    "uid": "0x891376d9a4f0dce817e6069f3f623e09ed05aab0162ff3f02e1e5b5c03a380d8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x7f67ee0c6409137c9d5564da07b5fed1f65c7ca0d77bd8fc587123f0bff7fa8c",
-      "salt": "0x2a0c46032606a759898c1a05b81672037e64e5ac1b90054632f07d26a16f3f88"
+      "data": "0x31fe8383883350d99b79e2e1838d4d8acebaeee37d5bee039df5d490fe3de9aa",
+      "salt": "0x3159e30108bee9ba59c8d5dbe61543ab8a7b3744d4c545a5d3f9be1c85e65053"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xcacb0b00db32bc5716f5594afc03707fd17922d1f92cf0142f7e8d019741a188",
-      "s": "0x73996d4bfefc8006a1269e0cf76622c2ba16c9764e0c854bc3440f977aa91f74"
+      "r": "0xdfe4ef2f52e5fbe51c3e0003a8f838369375b81b45208e8aca694e0c9418b100",
+      "s": "0x19affb7f6bda73e5ad5385fd9e2ef7d110d77515865630b03f1a83bc43288f95"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-resolvUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-resolvUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x51a47a22b1b6f6d391e959ace410379f0f92abb1bb89b964799ec730bbda66b9",
+    "uid": "0xf8d95a627cd641f6822220e2c67d2ce7f6732222cc9b8e2f3d68df3cc88163e6",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x386bbf4091b665ca17b025ca8f486d8084e94966b47b45590fe47384670df34f",
-      "salt": "0x1e4883ab1e5facb1927d49e846b68bde8268ca1ef78745762beaf41a80c411a4"
+      "data": "0xa6f5c8016386c2626362d527604b192b777779a565fe15d9d104271cc781b840",
+      "salt": "0x6014eb5c39bbf04d9f97ce62e227f0f776d15a453582e8aae4747af9d3084986"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xbf1af4ebbb2a0800ce6e285de2d21b7883adda56b9fe2663c90881092242985f",
-      "s": "0x53a3fe29b07ff0a8d22c853497a5d9d7e43b4656ba1a0fe548e4ef3726d36a5b"
+      "v": 27,
+      "r": "0x8f87178aaec92a39860a3b57d5287af044aa103b9b0dd304d468865a0e2488e6",
+      "s": "0x11fa02e7b42f9c46b01b604e63af5b28dc2eae9e1ceb0ab4427504796d5b4202"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-sbMorphoUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-sbMorphoUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x9088bf3824ee30d89ce098ed37c9a3da80fd8348977eeb4720d8f50485ee4c4a",
+    "uid": "0x502faa0306d98f8342b439d9dbfbcc0498c7aa5e63f27c41229e22ed6f979a66",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfb16fedf35ab3c5c89443d4dfca573fc8bc592ca6ef4e29e3b00dff5f37788e7",
-      "salt": "0x801794856b8feea1eb5f5f75ee563bfa40b35be69dc745d4380133b7a2cecb97"
+      "data": "0x34de1f76d83fb1a68b3b62baf978ae65478b166969b348c68deaabf3720b63ac",
+      "salt": "0xb7ed24ed0f89213af7a12ca36579a4e782f0caf9f36d67eda941e9d0e856dee5"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xc6c0a85a0e86ba845451b8d4a72069d64343dcda52b5eb804331f5fbb1d5c676",
-      "s": "0x3a1828a3ee25568e3f8c38412cdd29a5141a380fbb3b7cbc43eebf1730d28791"
+      "v": 28,
+      "r": "0x6093c1e9dbb73f02ae34c9173f2eb53110f3e6c916e0b2f7645c97ca2e118ecd",
+      "s": "0x5859758c103fdba8b7fe8268b0f6031317a90d88705b4b80bc153d4c43ef7136"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-sbMorphotBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-sbMorphotBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x595d6257099166a20ebab88d21d4de94ff0abe0d558f6edafe2e46fc37d72ad6",
+    "uid": "0x1eccadf34dd16eb81925c4dbe1635691c932987e10a6dcbd4fc14e09ae6bc2ee",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xad0e22a0a3973fbc52a5c6d31448d02b9a9e2f89eb2f347afb8302e3f5e88476",
-      "salt": "0x2a277af9592c37146c5509202fe5da610586b3971b4bdec752d0ecdd07cbd411"
+      "data": "0xf49d812cc2c4fc8d54f1d20709de22273ae114f5edda7d43944803b35bfef8be",
+      "salt": "0x872f89810a0e247ced6f542ccec7a6db5611388ee5ab7a9bf14b7a91ae8f0791"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x6028cdb33450048d38b115cb970274aea013de0669f8f1a14e84bd693fdc8205",
-      "s": "0x46de2acbd4b0019481bc47cd89f09bd4b2db19df60b0fd32e8f3c2f782b431c4"
+      "r": "0x5be1858e44b86aae8968b10b2aa9c32c46b61d1e1cfe63f5242ea01e73a141c7",
+      "s": "0x4498d5e1964f5e24f222b8750e530f9ae971d0d5b77c88b35e09ee1dd445ae0b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-smUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-smUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd0ca990dda1c0cc8713da1aa8a8aff2320c8b27b1ccd39e0a47521d41e421b5d",
+    "uid": "0x6dd7aa0876b9f8d96a970dc404c901db9cd77ef7f2105a3c22d0b1dcf9702c57",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6a9911abdfd7399f2943943da8651943fd1207f6414191846fb0981d1259ce38",
-      "salt": "0x1f74c3a4f8894bbe760fd136533d31d464dab19c5d51f2d44edc3016b38421ce"
+      "data": "0x32010a18489ecc718f2cdc658339eae99a720d53cb31770e9ccaca1e05fe01d1",
+      "salt": "0x1b9348450dbcd9226dedd8ea3d73ebf69e782b22427ae498c8a9ad525c76cf91"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x2aab271c610470bf4d7bbd975e05fd3d6bb79308bd3dd6c94efd180a6e1abe3e",
-      "s": "0x66f1e9ab3fcfca92458685fab14964e9323cf39c78186e99f801f19b305f684b"
+      "r": "0x481955fd8be38047b5902c5b98ea6d826fa6962181a03650a6af180e6591e187",
+      "s": "0x019e161a639b54f79b281e968876ebaf5e9c056d524523cca47fd9a17d7b973a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-smWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-smWETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc9b15acda014492dd181c40fee40a24db0af9f8b168a59069839627d83b05cfe",
+    "uid": "0x3832a905bf36bf94f08ffb27b95d7ab4749a0f3719ca23108fb95c46f1455368",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x36892e6cf5a128aceef8acfd323e74dd3a036072d1c2100750215809ce67135b",
-      "salt": "0x4c247e4d8761a46632ea559ce20c2f5c4cfeee9f359d7e4222efa75a7cfbbec5"
+      "data": "0xb2d261c8cd073a1c504f270b2632bac358ca0e7880f4a954cb5e65067bf704ff",
+      "salt": "0x61848d446e038b6b6d1a2ce30088b35de44ccd308a81e9fd3c4ca029ba19cdb1"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xe71e669619552d002c6ae1f3872504789e9a1e3a2c15dfa6fab0f40e6835aea4",
-      "s": "0x67a84b72e4af05cbc26c2c75405f6225e39d2d256dd6cfb7faf6355ca6f39557"
+      "v": 27,
+      "r": "0xbee39d84b01acd84fc83cc2f1ad4e5acceab6b2d025d96847743888aa36864bf",
+      "s": "0x25643d81346562dde98991811812f43f18b5591ea360dface07d0f6198216c5d"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-gauntlet-smcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-gauntlet-smcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3dda164574f103209ddb2884bd1344caf185d3c023373e53f5aa6306ee3b7de6",
+    "uid": "0x4d5cfe0b5880de9524ccbe6d9adbda90b6a07fb9d1ddb12f7990c23f0e5ae539",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x8c38974bb8b57044c76750c426dab526556f1c8df0f0cde94b06932123ef93b5",
-      "salt": "0x80c46837dc76c52c08f543dc972a38d369a5465efd3e88a38531474c0adcf340"
+      "data": "0xc8ff49d2633a262e80d51a1f52defa7e9c8f2d70c9ad2019aa6fd0425a58cdaf",
+      "salt": "0x3e78102eab840a66fcccdf75828abf2b5fdf5f9bd7ca5405587bc48df869bd25"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x0acefff7f3567b7d0448374f8fb4d0ad67d405f076d62eb9818f0a408beac6e1",
-      "s": "0x2a84b761d081f6cb09c6999fccb3dc727493ff4fc6e05d37ada096df92dd4c87"
+      "v": 28,
+      "r": "0xde9f6cb3e3f9567b460ca3f815c10f74387c8375111e2f6470fd6a6a4a14aa9c",
+      "s": "0x511e0f0542941c0e367d0e79fac0a6d1db3669770db33a0aa16bf037f3e4799a"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-hakutora-hUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-hakutora-hUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd364d33c0250ab7c90748f2541a4687d208a946c8ff32a84983dc0365d4b5da6",
+    "uid": "0x3e1682a4c781e42987dabb9aa603c87fbd0e5fa7ced37e63ebeb2f8d2ad0a511",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x753cbd4bdc138f5a26a71f19e449135abbf466bdc752bf4017934a543e50fb5d",
-      "salt": "0x7520efb0be58c00246373898f54e6f57afd0931ccd6e34afbe6b89edc21ca73c"
+      "data": "0x7ded885c85ccf6630141d0274da0b6145312df057a00c601b90d94022f2078cf",
+      "salt": "0xc5e93840410dcca79f293fc29b31c3ef987149ab0054addd5afd59d7814c170b"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x417d1c0af4dd676f43337b812303f66b66413daa3ccccd13b77d441ae2480456",
-      "s": "0x4516a389427f86d6dd87bea79fc0688b408fba93101d2ea6fb08803b7cca8d37"
+      "v": 28,
+      "r": "0x13775996a542397a4704b073dd227d1ea768dd2cde6cabee29a8a850c1525777",
+      "s": "0x284cb4584af3e4df0c349c07c3d92319b66347c68f6c7717eb3991054990c0fb"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-leadblock-USDC-RWA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-leadblock-USDC-RWA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xfcb1b03882a6dee880cd3e6e1d2ecd5f282be891eaf689a75adb74a1e4cebf3f",
+    "uid": "0x6dd9d1249bd5ed0bf42e35a8ce431189955c7d6e822291af5486b308c3e10eec",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xcaff51dd0d712ab4eca0bd7664f055a933363815d5affbb2471f7d9879f29f8b",
-      "salt": "0x17f4a88769cb01dbd1ff03ac4c6b4a5278acc2604c50c7c7cf435040b28990b9"
+      "data": "0x0d4c14348e3658d31535ee20adc84a3a641346f3e43f5e805bd6c45225da4765",
+      "salt": "0xb78f6dfbbf084c0525dfe75761d3d175b8247813eeb2a9050340d8c0add13092"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x6667330b00b43c0826081a643e58d1e53232a7a9d1cc8d5ee99e71fa213c4e61",
-      "s": "0x032d513122ebb062e70d0880e5c88164badb57c84f8c261691a1290d73d86544"
+      "r": "0x53a2315ec7d1f34b48069c1ece8ae239b62f9b89b7954f55ca412c9016014e00",
+      "s": "0x3eb7cbd46222206d50a1808f0cab72c26cade210ba923a168c9da52169a42535"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-llamarisk-llama-crvUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-llamarisk-llama-crvUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc2a6d2ccdc895598073754aa853e2c2f0e71b1ef2f6edb37f5901a4323f6a420",
+    "uid": "0xece99a7a0f1f7efea6d78f4b74601f1f1ff8e096eb276b6e08010366acfd3668",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x8f9aeaa5c3a0ba482c38823c0fa2d59665d266c106d9c4efffd7d26221e7adfd",
-      "salt": "0xb0f026fc09382e16d9f3497f527c8e2df24d5dcc2b17ea00bb49f87b04202e55"
+      "data": "0x7b7b2b2523d3c20303c3bb36e993328015faeb62b6ac65dea34cb8a75e08218c",
+      "salt": "0x846a5a4df95e26addee6b3f57053a3ec8862ecdf3c0b2f183d3e99c54093ab04"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x3794ddef424e890857b299f15c15976bcc8027c817447d58e313130358bcef44",
-      "s": "0x6c842af95ffe014114e37686f753a8632ec2018a0a2c7bbe8d819a161d4de3ba"
+      "v": 28,
+      "r": "0x1f8c5595bab459b883d9bda8f7fd4c38035bc8a935161fab5e4cbd7b766239fc",
+      "s": "0x16d2b57bf8bc13ccc721f2ca51636b4e32238e2167d62b472646b36d1203b4dc"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MC-USR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MC-USR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf3d7761418095494e431eaf9829e126baf06941e20877eddf6b67f3bef8af369",
+    "uid": "0x6c7f5d841bfe1064693012f6f9af9e529f0a1190b0d54e6bec32268557278a68",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfa8c1b2bbeaa6cb477ae941e584b330c9781010c676d23e6bcd5722aec679eaf",
-      "salt": "0x033fde3a351dd0fd55712192c6ee0aa7307c4a554bbacce41888d868936f60e3"
+      "data": "0x51ab0064499b9a1147d0890ded796b6c7f809b13e4074e75d03272141c7654e3",
+      "salt": "0xfe275a561eee71117a2f5eb3226d2db42ee437fe4d881d023ed0eda4d3285954"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x637de317a3b4f599c6d18ed3f008b5ba87ded9bfe5dd00c6d61d91d730364260",
-      "s": "0x49196e82070da298f56effa0073527d54316a9659b9e14aa272ac7880cc4ceab"
+      "v": 28,
+      "r": "0x6db0b2f9a268e13fc5448fe07637c0c744335bae932a36064a739dcb2eec2f89",
+      "s": "0x351fe1421939001bab24949c5e902688cc319bee3ce9a8b44481d91cb0b53fdb"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MC.eUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MC.eUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x087ebd64b920be1de6eb138e89645c6ca41b66ffbdeb3224de9ae6fc1e4465c9",
+    "uid": "0xb3ad0cd9e76a898e67ebce6ccb631c12865d2791b15647342ff8b7747f04d0b4",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x362bd1279d008c1d8d6bbbf803a6c0f9085072948d7f4e5664a843e2815cf321",
-      "salt": "0x8b0688f753587ebbf0a1be22d1fd47cfb11327883ce334270ca3fd9e59a82f5b"
+      "data": "0xbd64e1f18c12d228984d33c431361df6690569bb1112304637f54dde9ae8bf9f",
+      "salt": "0x5b2a58a4131501fde11711d6f6aa2af5c0e8efa73baf1ca07e43331a0bafbb4c"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xaa75423530cf36c73197fc6bc9e306d1b0c9601c4ec2287e017714cb06599179",
-      "s": "0x7269f5b0cf95f66b2830ab731394741205146b59c75866f39ad69fe1ca006577"
+      "v": 28,
+      "r": "0x0dabfa30967f6fdf535a6508f8a72583000cfeb1787566776844d96474f89fbe",
+      "s": "0x68fcb6e1157b77a127710b35763e58b9fd949f68b7ed0efe1a154fa29d92c6c3"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MC_USD0.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MC_USD0.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x36554ebe250c97485057a747a8049b6e487816c83c67dacc106680dfaa32e42f",
+    "uid": "0x219b894f30fce9d58044824842e7b5d7054b666bbf2b429a453224e40ffe5e85",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x85efd43ef17101cb5847d7c56ae5768e4df2fe0173118cd64fd57542a00caf94",
-      "salt": "0x71eb92cd4de8c5bd8772449fd23eab5355a9f7a190e257275583dd36acd704ac"
+      "data": "0x1c839c891574c84ab6419a89df845ae3d64b6fa22f06bdb92565c1ebd3e6f475",
+      "salt": "0xfc84413e336acc7664e7ee41853b9f16fc11d7207231526b37a62f2e45f23a77"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x943b91fb65f2cbc7135a239bbaae10a0555fb1601578239340e80cc3e058b7ed",
-      "s": "0x446bdb6c3acc37bdcaf86952c2448b79d0908a2807fb2182f28bba51668b4e9c"
+      "v": 27,
+      "r": "0x354364aff30c2b008dfa91f5d6152e4d31f6c37fd548b82afbdd54438a98a6e9",
+      "s": "0x60dfdd636e1afc3aa4502d14387257dd9670c5aa644ccb1ec6f4c1931d8a45bf"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MCcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MCcbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x4253c0532910e24235d314eb7112f748f8101b7dd549d9d3ccc5a4f82ebbb22d",
+    "uid": "0xcf203670c4756c30a5903e68ff3acb0755a9e3c0633c4804b80a96b853c4c92a",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xd61e1c670fbacd0243454cbfba11f78079d40105656f4b9185345965aa07053a",
-      "salt": "0x1de9797b34f5c8ca8ad4bcc71d145ab0cd4709188cfec762739b2be9b9f22751"
+      "data": "0xd8a634c65e938ca5b6e9def0216ad0ca1fa1ccdd2295e72276a33cc97a49002d",
+      "salt": "0xd30be4164ead1d3bc2a053a7fee0bebc1feac36f6f26e209dd83d79eb249ef53"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x52f3c2281a2f895ab778c196d743742c5c61d427f4c0691869591ae298495524",
-      "s": "0x4fbd80f433769a6039420644423718d4c92a4de4723a2727c84378939dba5fe8"
+      "r": "0xe40b708ba95305350cddd91fa0c5029e229faf6844738b066c4036bd423fa13a",
+      "s": "0x73e9c64637890efad2743513fc2fcc25a2a3d7740ce2e37db1111f4c0ca26664"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MCwBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MCwBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x504ee6c40475d9ccf01a77bd91edcac160f7f2600a7b433f6f4cb7fd270643ab",
+    "uid": "0x8de84ff30a092eb0d8e370ae367e3fb43e046021c8951f1913c20f6800c34e9d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x6d4b073fec914cbf66b2684cf6a5cd09f8abc84ff59b8fb30c9e855f77a86013",
-      "salt": "0x9308b1f52bdf239372ac51852eef2632680003acdc35c78426183b0656cad76d"
+      "data": "0xdae6870207f4288023965384487c72483887b934824b0eacc38520a4f71af7e9",
+      "salt": "0xf8c0bd4914f805b67a312031af1052ec889e94f357f5b9b3c037a2afa040e8aa"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x76dd5f96abc795fe4ecbd0bc289664928fb4deb61a43232cf7ba669ee39d3fec",
-      "s": "0x1187288018617326bfb07983ee760fb67cfbacf5f6a72e98d4bcac2dddf366f1"
+      "r": "0x570a77354d0b537b000d6a86c1d5eb7ea7424e8383fdf6e8235550c2d7fe2f4d",
+      "s": "0x743a7e6dbaea35b3cea96ca3155455d3b826572f50a724583934a4dcbfc1a19b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-MCwETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-MCwETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x10b2d395a244eb8e15bbea05b0aa0643e93c79f612fb233373dec30c8924095b",
+    "uid": "0xf8d10a3fb42a806b7c3352a4b6a089947704ddb51f292eb095715e1d69d13724",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x189d5c69ad8dfb79a2120e1d3ef288ac5d9f2004c1f51927dfaa335e676d7e77",
-      "salt": "0x670ff52ca2f0a208564cd674f0a893428f7c265c32c725352c4e6125ab50e684"
+      "data": "0x7e7c43683417b6b908408b741ee48243ca1913c45876cd6755e23861f6b91098",
+      "salt": "0x43d2b35166307966b2c1180f1dadfff75b2f19111367db265c38688979297671"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x2896f2b5d186500523b78e07ff45aec22924cdb65f53c2951662e77cabbd794f",
-      "s": "0x41cd34225d4a246aea8500fdb1772642d41abda7cd9a237cab74a08d7cdf9d01"
+      "r": "0x2b2fa56aab3616b09ac67665420e4b41d2cc1c74d997b758da936d6b726f19e0",
+      "s": "0x3f78322640c6906659ad62bd2fb85d1e25fd77e98376dfca45b8634e9c2def0b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-USUALUSDC+.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-USUALUSDC+.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x71773a8c03f35e5b238c3fb63ed9a41520b45ece640e0af7c77d82049d535237",
+    "uid": "0xe4c1b3b479126893ddc7be8baf74b5b750c37a542dc8693dc8e61d2aa0d7ccc6",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfd195e59bb6c6dff7839f683f1c5582712fdc1537a07ca59d711fe336fe59649",
-      "salt": "0xc030c7ec9a5e0b75e923475fd2ee3ade7933fab32a7ef3e858fd805a7a1f1678"
+      "data": "0x8f492e7a8071eda814e9c876d8998aacc2dc4993388e8f7631a9543155ab487b",
+      "salt": "0xa68b4551724703c5e389520223e42af6a3739c5e7b483d9ed9829e1bf4c8e67c"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xc03b918c2f377189f8325b55e9d33d34a3ab59f2823971ac5097620db10163c4",
-      "s": "0x587439506eef691b5a27b7d6caa0465825bebda5444c004c62df507d41045d2d"
+      "r": "0xd1e1c3b6d55e56084b4e3fbdcc19e3f944e03a8cbac100db6ca0727606fa6d40",
+      "s": "0x504b20f3cb1dc13b6bafa641a63e8d92c8460132661a41ad2dd99bab926bb790"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-mev_capital-pWBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-mev_capital-pWBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3d98976924a649e6fe56d262cb0c44a8cf736b702929f4baec85942017c207b7",
+    "uid": "0x62bbc37fb695cb423fc53fc7a6042ade11f4fbcc23ecfb069dcff4b4f27e60f9",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xbe9583a401487ec2f90aedfc7a7af491d258e383d53eef501584e2d15a4a07a0",
-      "salt": "0xf12de3fbee78247f1e0ed2f6e94c0a1a77cb6a5dca973efbae3330755b78cd5e"
+      "data": "0x606a5ef3701d3ac0cb093bf192944ec1d60f3fd8eb45165ec28149acdaf6ffc2",
+      "salt": "0xa80ab415eef3fabfedfb2b27a4632418597cc29a887c2b7d145f277af666492f"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x607da4c5d54ebb9b4f4999f96b8b1c01533306906292f8c0b35d4a09f9530bb0",
-      "s": "0x4a283a7c22a4c3332a9dee4da3ac57f31182908d2877cb0729c4f5dd94db76a9"
+      "r": "0x4144f6486edb7556aa85221dfed08399c4ac05879f8535aca8b9fcb93d3b7454",
+      "s": "0x7b7f2a46b1f0879189eb893f737881e8e9bcfd8f51dd8e061a975e07ebca0198"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7FRAX.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7FRAX.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa20cf03fdcc31f0c50f5d906015db282da36c93905d76b823d51fc7db49789c4",
+    "uid": "0x96a7ccbeefbba885b9403ca90d9c378bfa94d847fba631deb4511064a1bb43b2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x099ad66a4b5ee6a1ea63241349731e387674ef6d7b2804cc9df5f1959f895c6b",
-      "salt": "0x6f5e93027e64139c87b8a9d6ebf7cc4bec717c39c68e799724746cb8f8bf4e6b"
+      "data": "0xd9fcc156f8c2ad2dcfc067998ea7a01f073eca7446e9560d630795a8057412a9",
+      "salt": "0xd704d17877db70f08c29e67d63ffb318d7672967915071f6f89d84289ceb1111"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xc932d91a64e99480d4582a11e454d968217ebf5e82b2b0795cb7cb2ba3f77e38",
-      "s": "0x22a3f5a138a7fb70b546d1100c89758a031757788d7bc281b6b5a61b905db6c1"
+      "v": 28,
+      "r": "0x7745a1d4e14551c3620b24064f4636dc35c8a3737dc93fe2fdbd8339b58d8885",
+      "s": "0x37db82f47510c5f9074b1301f9efa4704f5c15aea70b5a6c5d77c1262b5fe09b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7RWA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7RWA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x0e3a1948eeddd0a08cd4e68288d66a9414b56cfbcda65af70bf87ee7c0fac894",
+    "uid": "0x0e4db520d6e69920e6a79d100936f247e6a93e0175eb5766b0243ad0ea2411fd",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xbfe312dd907020bd0d495c1c9c90c3009adaf6e7055309c6915084ae5dd804dd",
-      "salt": "0xfc86e088a64bb5969450e87e7cbc0597311ebc794fc10b4a94b47a31b496a85e"
+      "data": "0xa036a59a8843c09a789f7110ac819883766d2874bb0ba0da51c7357981bdd60b",
+      "salt": "0x8f414aa115bffead061c3bf45e20c338eb8d0d1b5821ed3aa42fed24ef46f23e"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x5d4ec9fcec740fc8e01956caa49fd15d904f4b9588ddd0d365e72c4adb958bc5",
-      "s": "0x475660fc8fe4541a6f1c689c476fb450b1c8ce9b5da2b380e090ae0fcbe8ef41"
+      "v": 27,
+      "r": "0xf61088d86289a86b6d46a54e7ef1ecf7656b5f21337f679d25883cc33aefbddc",
+      "s": "0x17543cd036d608632787b1bb0d1c9ff09c0b1ec30a4a6dade5bef16614811e16"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7USDA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7USDA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x0340b6dde2f804f6accac867f5fc7c3cc6a68e5c3683ab5bfc6898c6256b16ac",
+    "uid": "0x7095a1efbadca26247266dcc4b6f511f390779d75fc298403ad2591dc93c2aa2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x1d0cc593aa0dc8554b47546e7c39acd5c5700cd1d55d52a14ac331e85c6bd972",
-      "salt": "0x858f65b7772e55001637ecd7f895d4a7acaa5d74840ab5848a5ba27277b1594b"
+      "data": "0x12967bb5cccf3c8018991f7a2a242cbf4db38fbb9a014ad1f875045cceba8ab3",
+      "salt": "0xed53680424aa794a9acb5400cd94506c07f39e32c5709597fbc3f45b64fdbcc1"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xd3ab9f606fb5db7ceeee7d1c0904f2e63f74e77f1751323e719abb641e0a385d",
-      "s": "0x780d2e9893fd865c5783fe35c90d2fcfd7519ebdf18456a0f183ff5e06b68701"
+      "v": 28,
+      "r": "0x0e127353d38a3d47816b9f32bc175b283f9d74270345467a12448aa9172e77b6",
+      "s": "0x117f87d0e7ca4a774b6344850fb6322a60c3b09ecc657ade68b2c6b80dafa9b6"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7USDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7USDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x79062014fe65dbfb19cc94ac74fe7c6c50b1e37796ace9974495207196553263",
+    "uid": "0x55a55f81f9c964b6bf8fc79a76f899395132e49c5597c1c47738cdf8bc3f3933",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x5a27cdb92c9cf6b293109d784b19fb04461f1afa1c32284e2683afdd523fa6bd",
-      "salt": "0x464fe8261748ba29ad774a536f1029ff81518959319d416ac1c68071cc700d0f"
+      "data": "0x5501098fd377567c76d8fd7e9d3de377358d15fc3634c9b0f1a60f3493fbe0d2",
+      "salt": "0x21427c588d539ff267c3a4ec27314031e8d83083487ff7881a2a9122f4ed5ffd"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x08f1fb23f26afaaa1ed0584790fb32d8aff8dc2f57fde46d426fec3c1e129f46",
-      "s": "0x49fda727b2a2157df1ea7de72b1a8a1dc4733acce3e6d09ebf62aa7f7c237bdc"
+      "v": 28,
+      "r": "0xa930e201808fa6c1ae4c02d7a755721df510b7e81ba2eb8c79f640abc55e01bb",
+      "s": "0x448417982d34ee797c36500a77adee57d85da984f96bb87ceb70cc32c7d0b1df"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7USDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7USDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf6cd3e77fbaab68d416211909ccdbe7f8dd024e077bd1e35c26a5bded665e9f5",
+    "uid": "0x7cb1b211449cbdddff1c23d2172454bbbd159f2b5514bc499544e8d2b999bf56",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe824f9918ccb854107337a5a1d4303574c7947ca5b5e98c5a4507ef608773744",
-      "salt": "0x57d045b3fabc849ba52b26faa06953cbed2391415842138cc8867db1758b63ac"
+      "data": "0x32e01f5546b4142c3f062225e5675678b115e6bc4453fa14d44840fccfa0c55d",
+      "salt": "0x24bf144d53bee27807f7a88ceace321bc3377c3289ed7340b7491cb220587a01"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x9a876e8629779b7a6ddd457d4c5e644a2aed60d76ef5e31af0489fde5e0754ae",
-      "s": "0x2034363ae3ddd24c1a72a07f6b61d115c4aca9fef16d3eb5de1eaf5ebf624f68"
+      "r": "0x183f41dce2658c327ac3fda6327efc49b53b8c582c0d812f5539c2b2887d6ff3",
+      "s": "0x19ce5379d5cd0d233876a74db6f08004d13ebc40b9f833e1ac1bc38f164fcbce"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7WBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7WBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xcb6e4f48ddc9fce97f0d89cf9ace61d999cc31307579049ae0524a740e194335",
+    "uid": "0x9c2e51c46db3f51f128a4523057c869279ce62df9a5317df0945f5804e477ff3",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xdcc2b897f615910655cd1b5f003279d08605936918a0cedfd6b4c7fc6c179f5f",
-      "salt": "0xb8b71bf5f35846bc13f5bdff97f45a670411e73880e419d0e57ff92247f11e2d"
+      "data": "0x32f7fefdc870ed3a3630c57be68cf07831d337811d96c04377c86d4fad7c7654",
+      "salt": "0x00ed942d40b02865c7048797d848f8481a9c137072c05984348ed61ccdfd8486"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x2ad773fc75a9282c3aed72b8459e2c2f47ee84eebf31d4a30dbf68bc3140955b",
-      "s": "0x2eda02c251768a6775ad0ac73b56f3f7160697c982853aee9983ee3c4aa90396"
+      "r": "0xbe2900905e0893b7117a8d72750edbb0d47dd34265313490fc06200c177e9213",
+      "s": "0x4cdc1347abe8d2ac9beea66bfddde11ec4de6a16addafe57f2e1e284db7d42a6"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7WETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7WETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf4e814bef69387f2964e3daf24bebe85eef3382c90e0ab4a3bc13b5463eba8d7",
+    "uid": "0xce44b7e0168d02d4b75e11101abd7c171f3f61444227a80a5cf5a25b8ab4bf55",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x9fbebf97d1aebdf5d67c4ad6f612bab1b8f771c5ac47b5e90fef4bf1decc0c99",
-      "salt": "0xe144f4552ddc9a1872b5006d5f3956543cbac4c736131c00fd81522ae45d5186"
+      "data": "0x86f5f7283042723154f1ca3faddea6bcbfc9332abc2e2f4d289e8e08a354369a",
+      "salt": "0xfa1d23cfc8ec1b75fc7912c1f09f913a235934e1575367b46587c11fd63c98e2"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x002229b8570a5c1870afe1ed5e5df5c6dda6cf39daed38c3f5c5a81bac523f16",
-      "s": "0x47bef9195122d99c14446a5f78526d4ae914bbde002a1dba4a2da42693629285"
+      "v": 27,
+      "r": "0x991c3da70fc0f5f6ad11c6660a43d1cba53e23867e9240f982baf14e45c353e9",
+      "s": "0x58e0e14667a9b79b3e9522def6e60c95f502cd1626c47ca7688d8a26a4ac2288"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7cbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7cbBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x52a0256ab8120aa09a9ac5a1b98c58340ea3b73e69e04c552ed0cdf20f71b9d6",
+    "uid": "0xd66ff7f52c65e1b8cccf5d5095d11907967ca59ecc24b2d2ab3e23cf35053434",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x3c7ef257b504b615589ae57d1efb0b9337bcbcb5b224971472517e868ff8c7c3",
-      "salt": "0x31c549799a5bea9d9ef8190092913e0ec76188b8eaf665f250468b6f8c0bee35"
+      "data": "0xd17f477139a8e506a9be26dbcccd88b24f6a5e4944ff0103b4fa329cca16d88d",
+      "salt": "0xff60a6569d7b7b078e3de6a1d45f22e3083ca7873f88de6f7da021f00acb77b6"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x4b5a0857d6c8151e7634b1c3c8fef29fa9229044ad6187bfa69d6b78d2e2d29e",
-      "s": "0x07eaa2ae36744466126616619144a57826fd0cd667538b2f082d9c09d2b73960"
+      "r": "0xf2e2387e7e34dab29548c74e53a4a93ec3ff9c226f1a151b89fe3ced86368371",
+      "s": "0x7ae74fff0c3d4d440a75b35b94ceb72c6d34917a5bab8f5a74b60ce3eb0d5d36"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7cdxUSD1.1.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7cdxUSD1.1.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf0d9a52977625e75232ddb874aefdec54921f2b160d2b5734cd347972b81044b",
+    "uid": "0xb5dec21e04d90354c5a81e61d984ced8919fcaadbb39b25c4bef6f37c7711106",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x99607037a6dfb30153a31f6c1949260cb70beb6861cc91b5bdcd040ffc6ed060",
-      "salt": "0xba044bdb12967d4f40f0bbbdb9454d5bb4b78e1d8a25ec1eabf7eb58e3b3bc64"
+      "data": "0x19a170cc788f15fa9abe182857d3ab0c3c510ffee0dacead8e459daf1d19e8d9",
+      "salt": "0xb4d7f3cbd4ed81b4fe042fe4b8d17dfcf95ef02e3511bed14bab9993712365ca"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xfc197182a7a7ecd8b17c1c3a00d9b559e2dc5ababb31f9634f4ed442c864c1e7",
-      "s": "0x2be5022f3055029d64f3fc4d19471a8d1f7df6f3e01cbfb0b6db601cbc98b01f"
+      "v": 27,
+      "r": "0x65bde5e8e84499589a172e72ea911138730f4b2cb01e6c0922a0d46b5cc7a39d",
+      "s": "0x00cf87760731377e48683acd7322d288667ce3eac9ffddc4717632a3005531ba"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-Re7wstETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-Re7wstETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xff61d4711c1614bffa0a5ac165188b5aff01d5cdf95c66993c7fcac352e134a8",
+    "uid": "0x8bb557bf4b6aaac67be6b0fc90a1f1ad661f84ce0c55ef5294fdd5e9f526d027",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xb36a4a20131ca702ae42e40c089c1071d06bc93b91985b223064a04422bbf363",
-      "salt": "0x5ba6d96e8628c13c12f97aa8a4875a7835c4a252843ba3f1fd16c832bc224cae"
+      "data": "0x89712eb50ad62aa6cf6176026b25d510c998a80e7da6a6febe284c1d5ffe2ab9",
+      "salt": "0x0126c60f8e6cc77f93a82dd64660b6364ccf2b5bf034eb7e8f08896585038542"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x0ddd2834ee1dcbd801f825090eecf68fda92d42f9d7befd4a6219a3d33aea4e3",
-      "s": "0x45f38617a6cddd01f597c3d4c7664ea0bf2b7e2d7ed2f9c66d3ba1c7b9af820f"
+      "v": 27,
+      "r": "0xe36e5e38cdb70305266190d72ecb971c53d2be97487eebc4f76e49d959107478",
+      "s": "0x7ba24c56e8ea88e5436620812ad7eed18925544b2f1dba4c9fd7a64b04f918ba"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-degenUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-degenUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x10be5501de9f6275dc81a5477e4431b23c675888c2cf98ba958ff93af0451fc7",
+    "uid": "0xb4a082f47b16cf0ef4a163473ac16e7b4348823cea3a5e5b46c14d3e72490029",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xee02df75f308b14a5e2dce0cdfe06538a8a11db8fe380e423771f9ccafe6bb2b",
-      "salt": "0xa364727c152090cb2f2f8271a202b4360e7bd2ba500276be2f9ca80d2273e3a6"
+      "data": "0xe4113b30eaf90a4624e88fbd55986228398265d7ec65c4118c58aedd3fca9e13",
+      "salt": "0x142ca3420132c2cc8725c470e41fde182d1b8051ee3d381a3618d10c14a2114c"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x5b3bf5be765078ab0a9ac19482c74227b6179256e5fcc601c8e5a614adef5968",
-      "s": "0x26403900f846a69b21f0854b30dcf4603ec2d81f9f4f04566ba3f3caca3ea00a"
+      "v": 27,
+      "r": "0x11ec387d80df849ff4c6c9ff4f2926b6a89c134727db00d2eb34580297c33ad3",
+      "s": "0x123801a3af116e28cfb266cc2947e079608382192b3ac9711be9ef3ee067ac7f"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-fxUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-fxUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x06e1ac82a6662809793be776ba35472b418a0d16d6f150d63fba3ce0a0af9f94",
+    "uid": "0x658a880a85f81bd595b5f9a93082a4b8a8681aa744adedc92f55cd3daffe63ce",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xdb9cd49ee1cd16b44dbf8d7b2999f5d4be70de284c878565ddb4cc557e0ec7bf",
-      "salt": "0xb8e438d218660fa3da5c3d0a5a36818a9cb66b95a07f2c6efe2d81d4bdd3df17"
+      "data": "0x75f9d14585f43515e3f43246c268ee7d0e7de03862b4907dd2a79eb31451763a",
+      "salt": "0x2471c0f883eae03490353444bce48ec41d5a1b3f6d7a2d5f307bb1b2ae2013c6"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xf0933414ad599c1a7dd5f8794e2432c8fe4acd5eba7ff241238c654d05fbfdbb",
-      "s": "0x6c53057fad4f8d5f82388b2a32f9f900b78055d6b08cc163a425846590aab09e"
+      "r": "0xb74b3a50d0c946b91ae3625466f1c8b905193facf4bf9017f2fa250b489351f4",
+      "s": "0x5f3a670a333b28276f5ea27d60d3a693dea533066c320b57320f5554b27d45d4"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-mDEGEN.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-mDEGEN.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb191586dd89f4772b76a49d530c56b6b714422b545f33f1efb88c92be9a0a4ce",
+    "uid": "0xa8807c27a9924ceaa48d8f04b71763c30457b69b42149e1f1d50d2846051e2e2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x3b16ef34376698669edbeb1838d9e9b67cd7a753dfec1d63b5141785c6e49b2e",
-      "salt": "0x3c3d3f2bf4f978f6e4ac8dace8a3fc2e9b85c72cb650210b705af94f8d46a0e1"
+      "data": "0x658280374b4650283746392ef0372c18592b378ed39868f4113e465f5e7f4353",
+      "salt": "0xa68759e5f78984fcfa0398f6b5e4cfdc6e6b08a51baaaced9ca524fb87fecea1"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xb071b9ed384386a9e3afa0ca01f6a21e2a7b7484f747e1159f08f088bcf19aa5",
-      "s": "0x59426805c6ce1eb518d983ed4d763cdbf10ffa92a9c38a3b1b50e7ed52f3a445"
+      "r": "0x1b36257aaee4f8dc3ec4f032f699921090ae42f66e9b8ff9b85ee358f15bffe1",
+      "s": "0x30715343033f26579f0feee846cbf27ad01602273640c18823ffbcf0d18102ab"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-mMAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-mMAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb845662f5e33ed3baf6f2621e7918a5786a115c4e38c11d0ce843715499cc179",
+    "uid": "0xb7dda72971dd192f9b3510780f08996d831636f77a698984f52d602efd8b0e8c",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xee7f2bcbca827a9eb408d66c1b74dc0063732071bdc0fb5c5be4c742eb78a719",
-      "salt": "0xf140d365ea7a79d46653bfcbcf30e0268c5ad186bb93ba94a3ce8faa918a2818"
+      "data": "0xa28b87879a6d1ef38a43be55610ed784ccec4cca785e5bbbe329e9209e8f1503",
+      "salt": "0x25eed7f71cc1c6f78fa9e3330c437a94a2729dfab07b5186d8715a38d68bc1f9"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xd49dcc2d598f78b7da72976bd85f9ab6515112110d54af7d2d7ef631325a9f21",
-      "s": "0x05e5d89eababc4f39091b3fb6f3a588d561e63264ca279a3f1d9c38722277cf3"
+      "v": 27,
+      "r": "0x2e45e4ea3374fb1b8966c16ef9cb05ba3518364d15a9973ff3194b6c4e7b085a",
+      "s": "0x77798af536580930d89a9e605da9ddc14f03f94d8018131a71c566f49800a5af"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-meUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-meUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xd0c48e047718ef85b2d105ad7fac0d0a85ab6ead8fb1b3c84b8d9b1214a56007",
+    "uid": "0x77db32785bbd4de25a72071dc96f6e382b6bf9b4f856e15b7238873503d7f73a",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x791f5a2f3c8737a83a4d34db78eb28d467b0639a3e7cc6a3ef80e3e62235f508",
-      "salt": "0x66e69523590ff1abad3e62f9b2fca9f9fbecc3efd0b518d2d594851b5b2aad7a"
+      "data": "0x045abdee19dd1f412635e3e9f4d171019dc5f42fc3761d6a323be0a46a1bb06e",
+      "salt": "0x5dcd8a3440e0f7743383d0b3a64d2ecc09b8fe8d928bd18b31c352e987ef9cab"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x165fd040611ab1711d9bb63d42d4f508332a9e1e115729ad40d2ac45a635860c",
-      "s": "0x7113c049afe15d6b3bee394882494291ab3ea976ab4bcfdaf818fb6231ab0ff7"
+      "r": "0xdb78c923ee6d99f6094b87a8f4d75f46cbc8f411f44c2b6d4071988e566ebee5",
+      "s": "0x0d224a5b8d0a20263b1c62c21ace66473c066f7c4ef065ca5871612035e44274"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-pythETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-pythETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc49aaf5d39fa064c6ca9858579d08172f418ad14dec6ec212728319ce62f1585",
+    "uid": "0x45edec6069ab9016c453dab6e3bc4c5d17e11df71a25727d56c24ee0ec79b93c",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xbef39a49aa052ede7ac3d206830c06acf20f799b99415653bcb70917acd62968",
-      "salt": "0xe86adca48d6e2c1ecde70fbafab3693f3adb27599f2e7655772cc24141aa98ce"
+      "data": "0xe18c9133e378d620fa486f805cbfc6858b8f4dc1aefc9a3010029bb0cf87c8b6",
+      "salt": "0xc14e1fa275b43f5a846be527afdb9ec8059633f8d04d0ba8966c9ace3dcb0850"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x99607a9f950422c4debbc2d1686ae04ef1f26b7db9f9e5bb4618a42675b41024",
-      "s": "0x685da819b9231c0aa7196677800a05d5405e16bd150afe30b3f43359ba70b1e0"
+      "v": 28,
+      "r": "0x209fcbaca9abf58fc8960d740cefbef38f5a1f9347f9d78b9122ad4f6a196814",
+      "s": "0x493f9150042093999bdf2400328806d662e4335ce499dbc727d7575d12550791"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-pythUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-pythUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb7521d635fd9cf437a6ecc4b9da5aa016197a01f4d7d3cf0c655e0ef5fd13cb7",
+    "uid": "0xdbf3b86af88259bb5bbd047ae2d03f37a3d925541667539027a8edfbc7250d65",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x44dcefc335f4df62d143b9cfca2c6471cee246f9975b80821b99c453b85bc1b3",
-      "salt": "0x676c6975bb7510426f2513531c03036cca477152b52fcbbf4ca01549821c4835"
+      "data": "0x57f42b5da4fb57a76860c9f82c5c2fd79fae95a9301c6c1ead8dc33e1426210c",
+      "salt": "0x4c31e5b4e9752e0d9c76711c7d80fa0d219b6cf45be9f99b28f21b09b4e4cffb"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x00db50e634e2a45b3388933ed1743fddcdb7f82c6c851d2fb871564e4f8936db",
-      "s": "0x427b6287cc1ed41f3da1451ccaae350099bb4d16136a86afd3019bd6a7c9727f"
+      "r": "0xad8de27c3745fedce028a8caf8742c4f81e218ea41b7c56169845bdeef34150d",
+      "s": "0x73c7d938c4504e3011b4b5e7a59eca4108dc768dcea2024ec224f3fbcec52a00"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-re7_labs-uUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-re7_labs-uUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3dc8400b732ffc91c2afc605c6e59b7835316be1f156cc08643a42dfd3b26027",
+    "uid": "0x12e9dc0d91224bf518eab5a92a5561b5a2052051f596396e53b85c7488c2dc41",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x375d4a996b3618fcb60322868e6939b20e68f0d76e2983ef38a34349abaa96b8",
-      "salt": "0xc21a0db020b9e02fd7788ec48b4bdf0d9850a314273fe538b81858628841a74d"
+      "data": "0x3b03f0c8edea7d3704b6368a739bf033d91a039bbe3e547214b12bf443232d14",
+      "salt": "0x29a85cec9bc060068a6ade605639ffa86f1a84a42edd8d28f2efc73f84e31560"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x8818ffe241855d94cdf084957ad11177768259252a8dc6ac8704b108ab2ba556",
-      "s": "0x0123c70f24bc16d35b3b2794c6d9e5656ed6a000ca4730e591e20eb41a336911"
+      "r": "0x41030c12292e70cb481a7772635f7423919dbbd11aae6e9348d8387417227c79",
+      "s": "0x294c4ddc95dfa19b952b3cd54ca7d302ceaee0f935348bcb4326c421ecc81a31"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-sparkdao-spDAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-sparkdao-spDAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x69cb1a52d7fd0e522e2f2a30e701e831358cef086a2e7d14a075d88552d0abd8",
+    "uid": "0x6c058d218a93073785a31bb65d01517df84b10b635b9b207697fb7112c4bfaf5",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xa0c5608d0fe2fbf045d051e4cbb7f6b3a90b0039cfcfa4e13e37586ed43748f8",
-      "salt": "0xeef00039891a4128f319304c159f8b732e6de8f721c5c7e0d4ad0c9d0d71753f"
+      "data": "0x31ec4b286ce7a207a612fad26373f699cf15322e0cb4386d54af66df8e6571bf",
+      "salt": "0xe753bb4ec8904404b7ec092cc0b2f6735d9c4a7f6a1ac12cd3be991360d262ed"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x9f79d01d819c708c956958eea0723e0be400af8b716220b05e7b0e6bebc7c495",
-      "s": "0x31d7dfbdc5435968e342fdede965d112fdd18d8a4ea5bba258e662c4e2acf07f"
+      "v": 27,
+      "r": "0xd1d94770aa60923c2332281965e4f3e935094d6f6e3d22127aa5d84389088673",
+      "s": "0x1d255764b955a333e05b364fbb23b4c4d755aeb52e8b05cd2371952a9a618ed2"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-sparkdao-sparkUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-sparkdao-sparkUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xdb2460ffdc3172d7b6552d8d8140b1bc72fdf5c606d1a0fee999d5b597bbd04d",
+    "uid": "0x85fbc6cd78491298fb0e782be082fcbf79643f5a694882ad1bc948bb20248b47",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xcfc217bed3e4f5dacb3bcdf448f80c88f09979e45d4621724352e11163987552",
-      "salt": "0xae048a48ccb206774f6fcd8836eceb56439fedc98657cb7b0cc748c975e16373"
+      "data": "0x489158dbdc448d753c55c105c4d41898b6c32ff6ecd76c950972558f54f42d24",
+      "salt": "0x6f110725b7b178bb4c1bd9ba02726c66fa114249a36ada203f5528af488cd737"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xde650ea956c90249746904027fdde6478837f5e94f5dc8564d98d7acf2417341",
-      "s": "0x3f8654114c2562d2c2a90daa953737033ba9515973fabdd59f27d5b7aa87e7d0"
+      "r": "0x5ed2c229eb35d4b4c364ef1300f59cb5cc8fbe5f47b91b4e155fda7e82bd2e3f",
+      "s": "0x59052d98630b90ef17ba56c38f972c6baf94624a179095ec5872ab2c79b71f7e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-bbqDAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-bbqDAI.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xbe5624c7880ba70b0451fcc23e4b7d696ab15105a95c0d210ec6fd755ada2051",
+    "uid": "0xce51e7d71eaae8deeaa84ade7d48a655063b202b1a5c16a6591dc8d0fcf06afe",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe2b3feb59f7fbdf110cf6b5dd341737b6a0a8503ea8d5b0d128cd82c2cbde70f",
-      "salt": "0xaf5bf799152bd5daf5d887502ed97f8b26f3d965ff20752a41cc07e9c166923d"
+      "data": "0x9ad8d8aaf3b424055f11631e8ed202bead6312b63ab572d497a42f0ef44d2e43",
+      "salt": "0xcee2031729b3c5771b0558d940f1acd924948df32c5492d79bd7b5cf01cea500"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x2d4e3c7909352693dd7582f47ab745f19c918544968a6f7ef57f405685ba6c8b",
-      "s": "0x3e6e1a34ad916fc164496f3bbc9ad8bd98dd5fe3ff63f3770fe46dffb835a603"
+      "r": "0x4d33c15bb47f01a0b3c216a0c0b11b328e9ca0f55ba95cd9c06f0a41aa9feb6a",
+      "s": "0x3a87344370155291f44d2f245f92d7ceeac20b09f01b59eb71acce7b66a2de4f"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-bbqUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-bbqUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x08a4650737fc98eadc6f090cf5bd85f1f9a1784ded49b6d64bac15f62eb9363a",
+    "uid": "0x951da73f1e8d94ddcacc800a324d090581da6c78b1843a56625f2ab00d61847d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe42e4f1a9d8663918e935ca6068670a0341eb9d918fa2461a6341dffca275379",
-      "salt": "0x8aebc22d745e28c989e4f4125004841edd9e771ec25027d5fac4ebd3893480f4"
+      "data": "0x5d894d892e605db377c8d58b73cd7afc45b17c47ff4f2f4c97ab4e032c42e4c6",
+      "salt": "0x6619beb5d077818d3e5ba83843a4b06aad6f9f6b7c8643ae13388e6c1cdc8c79"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0xe89b3f0d359d473b2f7f5a13fade073c9a0653caabbd28eae0b0ca0ca3fa9b60",
-      "s": "0x5fb1cb0f61d5d40561659918b1de4a9c599e50c24f7693bc0b49a453a6c2f47a"
+      "r": "0x00d729fda9b1535300ff26a502a643454c9f0bfc268ddd0301648003d9bb0977",
+      "s": "0x192a5eaa48f5c8cf4e7e52106e3184cd6bf0e83b95977100977f285330918452"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-bbqUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-bbqUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x401d52225b684e03467ca86d4c0f6e9ce973f655989ae42ca57eb43252418787",
+    "uid": "0xc69c3f64fc1f877f71fff722e4358e0c556e0921f20f07a10bdd1d1942f6a0a8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xfa537dc80e720e9d15a1368a014cd8a3f9aafd7086d2f451795ca3d4eaa32e4f",
-      "salt": "0x5e92e662c989bfffb73a944d7fd1ed8d073e8633ce7afa24023298d531566438"
+      "data": "0x62bec330a4a5e033c0f7be584b37f930193c2351f04775f3f6b3e473eeaebd53",
+      "salt": "0x8aa154d56c0a0572a98bcc07ea5558b06b263051ef78ece1ab80e05725187e30"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x27c6939d5b57207b61d34bed67457d92d950324fd6b4f9b163d197bd6105c5c3",
-      "s": "0x44c12ca9770b58976db95bbd09a57dec3408e64c47cbe26aa4c95a668cb19656"
+      "v": 27,
+      "r": "0x405ac0bfd6b598df889612ac5a7fb028184e57da7418be0009239d9205f73f58",
+      "s": "0x622f2ae483e854dbfc721f11886b7eb5dbd34048503239a1046428951c866f85"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-bbqWSTETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-bbqWSTETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xba096ac9654d6b7cbdf2bf62a6107b4d5fedd92bec47f7a1962ff69f2fb4cc05",
+    "uid": "0x961207c12625ac1a80d682eac6bd5e54e259270a803d406380e5c5fc7c9261a2",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x3f913113dbe770f60f7bad8e71b3f96ce022de6222e32cfcf76afcc07d3f7ba9",
-      "salt": "0xd99ebd91f13ac1ceea6799a6015a87ea4ef7ea55463d6658f7abd701294b86fa"
+      "data": "0x31080db6f56bebef2a9d51c5fada7e5e59b5cfe07b320d03b98e14320bc0d3b4",
+      "salt": "0xc59828b686df667cc2c9bb5e238682aced3f2ba1da8c96765c5302d5f3031d1e"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x9a40317393eff46cacfc49400ecc1361fb227cf30d68fb6cdfded5e6dc189f4a",
-      "s": "0x760b4456564b62a4ea4a529f353b612b5f8654cd13cdc784f8a9a54e4cb9e82d"
+      "r": "0xe73c3f792b38003f2a1bf4984f0c8ff0a26b53fb510b96070712c3606114a8b5",
+      "s": "0x42b0f4ce1cd37419d666061b9ca981c10f728c9917e9a3bd24dfddc269ce9ff4"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-csUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-csUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa6708ccb5e5d8a910ad565ff10405c8a60b5c15b4706110395547f5968dc4b08",
+    "uid": "0x6da7936317f95db411c557267f172e8724b3a47d802a0b18e78ed23c7d7e8f54",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xcafef24a42b7a7c7a1efd5ca525ded492f9fb58fc7e2593afbb6af95faeb4b5a",
-      "salt": "0x5e5cb6d017573fb97d4b2a21c484a0fda8deff37eebe3697ac5313db2cffd588"
+      "data": "0xf9b62b23aa30d438db1b831ad3b03ada5e1b0a36c66c00bad2e14bfd5028ffaa",
+      "salt": "0x4de6d57c40108ecde9cd81c448190224c7e7cc1558814a6a5592cb0e62c66d13"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xb57e63922d58f463b9f010107bbded4977dea509ba69c3186fdd75e31044cf68",
-      "s": "0x6764ab0effb383d8a2b849d55efe512022fa401e35a3685f3c3cf25471e22a47"
+      "v": 27,
+      "r": "0x92dc850c32edf692189bdb96fc5995a0030c3105ff1a9f651861842a12c9c9d7",
+      "s": "0x1800c2c733e87c6a07935b615335d4ebf419b486bc6a4d1122575b37d826c7a4"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-csUSDL.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-csUSDL.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa8c6a5d2c60ef97ca5edf25344889602d2fccae631d163be7fabb429b5ea83b1",
+    "uid": "0x551247e2f1b93c192a2f294b6c306a753065394fe2b0195cb8168b1d20473c96",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x9aaa07a2166fa4497a8d4f6a4182b8186e2faf0e5882d8e0b119d65a852a2d4c",
-      "salt": "0xa35ac4b74b3dc172522b0ac6b0671057c981a8833af66bce60c055b70d22ee66"
+      "data": "0x68b73fbc9ed35aa2a6e816a007a7be4c7baf4fababec8bfc98249c389cba573c",
+      "salt": "0x5f2ae45ebcb7233a01f0a7febaae3d04ffadcf9a97900909e83b52ba301ea7e3"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x1df20fbc665cd9590907c887383f8e8ca58a1baaf41b3c1286800014608276ca",
-      "s": "0x0195faefbf2944ca182974464cc30566ce47c9ea8a67c502ccf0d7ad11a22c75"
+      "r": "0x5311adb455f9594c4ac3361847dbd33bcd2188d3ad06838adc38c09111cffe10",
+      "s": "0x7a2c3332a3cdd53c06ef306df9e5a566c281305e1dc826f389d4babcbdeaa18e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakETH.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x778207800ea2c719fe897156047fe864505f90c01d49d8465fd94bc073177a62",
+    "uid": "0xde73e279dd42b5392efa34d965d3472ac92613cd965428ea0e1a5ae914aab17d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xf13c2cc82c373c509919620c99dbb2ac206a64527cf39ab4cb98890b68523ef1",
-      "salt": "0xe9568326a204940395ab98130715fd985f772637425e131ef9021f6c71a5ed14"
+      "data": "0xd23967e3628dca707d110733f8d9f49005769dfc8d7f9e170311386bbbc859e2",
+      "salt": "0x49b474218ac27cd0dc1c26b734e90a5f99605d55254d1c4dae0db0b6938f1626"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0xa11fa1a5b36b95001bbc2a3b61240ff6714634f03ce113148bf1a28f81a40d6c",
-      "s": "0x7e795425c4c175254542e3b40ab5b7ecf5b54c14ebe39c7db6c0558ca7ed7ca3"
+      "v": 27,
+      "r": "0xc7b9bffede9c6537b840690801c0846a9a8e3cdd5c33c0e9910dc5f84575a667",
+      "s": "0x5aebceac8728bc5a56d729311227530b15179db69ccd34351996df710012aa3b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakEURA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakEURA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xfe7c60d0479976b4bd70bfdb8961bf238175b5107a26d3b814fd9643e2c6086d",
+    "uid": "0xbc4907ff53d3f7ec22da35de8036e812e7736afe74189e1bced2e9acf05535f8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xec7b2f48e6913935c38de512db03de4555ae8b8dbd3379f688ad38c1208c42f2",
-      "salt": "0xd0615ea8d18ff4e8d76a43eae62e5310945381e50297a4290884533545953121"
+      "data": "0x267799df6fc385b45e0bbfcb11b20f9b096ada0ed4bd374c8378cd0a528cde18",
+      "salt": "0xe71cbf3a9177fae1141a37abd7c88e49d9e5565dc04d4b0c6897d02ecc720871"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0x2fa61e95ca630e7e996cefe7cf9a935e9e9c2fc77b2ff73d2f666668f9b8418c",
-      "s": "0x1eff5beb058930014b3762aa585496724e9bd39085d06c0f99f7d4e4237f61b1"
+      "r": "0x429e696726aed1600898eae916599d1c73e0f20b3bd1f8e9c5a20363196e5756",
+      "s": "0x1816e3939c8cddc522de4253e9724f1da1bf95f05f056071bec4cfb0488dccb8"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakEURC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakEURC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xf5110a18e9a3196be1f8fb465867b8d4799ddb2450f05e0d59e291aa0cc343b5",
+    "uid": "0x3e94901d09371797ccab11dbce499454be8b94304b85de0e13c2df458765fa24",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x84b3bb07732d6d7d49dbbad2551795f1c21e21c5fc994370e1ab46b316a25c57",
-      "salt": "0x0f229dd52211fbd7229b322c264d7dd0e4c4511950b6abc9587627f87bd93408"
+      "data": "0x928c7e635cd0ece550919d94ff7a3ab2727865fd9213450ef5f69c83526c6b58",
+      "salt": "0x31b6a3e0a4829cfa678bee00bc19ccad5da199e9602eca63dc3399ca25ad3424"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x6d8e439c70dd27c88849d547eafae0f5387f1bd9a9daba0ad58e95f22b2bfab2",
-      "s": "0x0cae7cb63ddf56e29d5772e957476af993d6645017c1cf02f5e24d437887b04f"
+      "v": 27,
+      "r": "0xb857ff4a873dddec2ae51197c3810fb81b70c38ed04d2cb72a785161fe461b95",
+      "s": "0x49757eb80106034883a7c026fcfafc5528d97b1e197eb7e70e0a56e963fe5786"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakPAXG.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakPAXG.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xefc0a31d44b7b35688fca616ec3edd98057c103d90fc59c4ef730c535bc63c4b",
+    "uid": "0x3107f585751154cb3b53719a0b4f8dfccbae5d4eca04633e90484f6092221cc3",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xd27ded16923d15dba7e3b3893c60aa113f6a3cc7edc501f8259f868c1c3512f8",
-      "salt": "0xaf6b8be590cb09efeeff17be6cab5b2a9f3aed66e499b4298f37d5dd5ac1c3a3"
+      "data": "0xbe332f92de741381cf95ba81084aa09c52596f0244a5ee412ef15a3b41621b51",
+      "salt": "0x6a50e6c392b08ec5351f31c8677ba2e46dbc0f9aa24f69822ff76f674ef415fe"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x8fa544f2b80e045faf97182d3692344b10fc1131ef769de9caaf3bd5606be6f0",
-      "s": "0x5197a132fb42583c577e9b51927404579c18bf219d1ff0f070756778719eb6cd"
+      "v": 28,
+      "r": "0x9835102b863bff71fd6656c3a391337754589ad706cddc4786513f03f4487d1a",
+      "s": "0x173510d7e8d2ae85c1befe01294fa704bda1d0e7682846def05db4fa1e9dd3a5"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakPYUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakPYUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x55bf3fc5728fd81b784275b42c9225a136704ac9dc564b07658a64caf5c32a8f",
+    "uid": "0x2aadd5cd934bf744aeaaca39c9454a414f593a75087763dcb62f6f6a91235528",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x5f309070c5aa218960d1ffa60210c747fafafa7d59e424bbbd8e9b0a8435515d",
-      "salt": "0x03694e85ba911ffffccff758926f0ab549ec102736728d35b51d69a0c18cc6f0"
+      "data": "0x56cd1b32292bf64a0ced25c8ec941c62c1e695e81ddaa1f22272e894b6ed013d",
+      "salt": "0x067be0b83745135dd33c75e7b275ceb06b05407dff44a6f9e6696555099bf687"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x8c562177d6032950c59b540a1b09c60f8aa7e12b37f07328c13487d1c4a378a8",
-      "s": "0x384fd40e85a1ffa003280717c87d2f751b12bdf5ef0b96cae496b5334bf3968a"
+      "v": 27,
+      "r": "0x134e65d362b93fe114eaecf739d0e492e0ba1fb7064c6f81b141375627cfd5f0",
+      "s": "0x223b7915a4fa61497bf1133ca3fd94bbac89a9b76e652908527e7627acfa0d88"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakRUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakRUSD.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xbc0916782f4ad22636dc18d3b22688b36ab61ac3732019fb2607a60bc91f5bb5",
+    "uid": "0x39051f790d1c39671a7a83781637f3d8c1b4110150851f19514bc76c7b3dd19d",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xb88a3651f54faa1ab718e99260698194216ecdc95ce82842533140772bec236e",
-      "salt": "0x76db5b9d273da82eca8fd8b8f882246cd5bd802d6fab3f4b3e1b3d68785661cb"
+      "data": "0xf584202293c17ae754da0de06e42065f18d3ad820bf10f2a3cb8fdc93df05d2e",
+      "salt": "0x7dde71412597483a0955769f88411565e6dee9868e32b351fb872b4f049256c0"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 28,
-      "r": "0x26a53ab266ea68621a19514a6c8eac66b32e3e66885bca06f88d0b97fa82736c",
-      "s": "0x11e5f905765c57fa2610dc6342fed3879fcb6b30e5989f41c813decb852b9478"
+      "r": "0xefb96b6474fac689ec593a602cbd30dcf990648e87c1f7b0b7f9d6a04399e876",
+      "s": "0x0f936089d1767102fd2097533e627495574b7aa6c978a2ba63cfddb655f65e84"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakSUSDS.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakSUSDS.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x8f90498cf23adc22f7ee84f2644195b701984ca453d2278f49c6fb6342f1c8a8",
+    "uid": "0x7265ec790a21a13722b326d918797d351dfe1f2e0669526555a9d74c293f2cf7",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe57ee4b5d0ffc7f5bb7bdc2b7ebc6bb0f3019e8bd472a19d4896bcb08c57017f",
-      "salt": "0x4adda084cd1a8c9bf45cc2974ba6ff5cad26acfd9d555db5db0765e61aa77291"
+      "data": "0x2edb00cc9c504b5d8e2e6ee587cb7a811bb5a3139f2b6cede672851929805c23",
+      "salt": "0x4cec2e9b177c4a2ae1189a944e0b47398a97378f634ca61e8df5ef401972da5c"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x635f765e0f5eda0df9877e0664600fd9fea8a2a78b3f57df5234a8ad578b01ca",
-      "s": "0x608a6ae5e56b348eb8a2e2c6871b67350223f76205e02f0c78ab30666e6e97d0"
+      "v": 28,
+      "r": "0xd848077144e3fc69c8cd17e19e3f94c94861af73304042044e1da0c4d745cde8",
+      "s": "0x628c2bdecba4e960ebcaa2287394799dfeebca1f547b5f6ac8dc5a47bc515aca"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDA.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xc55a11a197c619db9d95bf0e33fd5cc9e907eb14fd1a94d8791595180e6503a5",
+    "uid": "0xfc7dae0b81aa1903edf74358ff1c217ad0dd4e4d9a18a981ad9f1065ac9c3de8",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xa53147014633c6f01e3595b3b1c13a8366035d1482a7feba840ea5fb9f24c306",
-      "salt": "0x022d3d54c0c8dcfc13781cdda09dee0a993b7a32dcba2576b8422baaa247c30b"
+      "data": "0xa274347946f2f01ef9655497ec21a31551f52858cd8c33b374db086b69967432",
+      "salt": "0x44806c76aad8be3d3f90450b26629c956c62185978381fae88c93d4f213ce0c0"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xfa04a1394e725e91a34a773749bb4b082bd38e3248da4bad3d0ea21540937152",
-      "s": "0x28c88065bd50e96b11d3aae863c9b515949818db2010cb3a53c6dacda9158f7c"
+      "r": "0x6b93a267cd317ea28dca1cb9ba7fe09ed67b1580a785e69465fb8e211baaac73",
+      "s": "0x26b7147628c51817e80e291bca8a9c60fb8a52cabd7ba53a60215ca061e36040"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x3d59a91eaae3a07555e6ff62404bc58e7116e0a21f80eaa60a27f2ea6f62c075",
+    "uid": "0x9274036e38e7873cf0f5b33a70680c62507934f32a424fb040fcce3e5d159ae5",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x486bd10502801f47bd5a98f174bb5a03ce5ed7df4bdfb2c5291d3f4017c17345",
-      "salt": "0xc7b48859bf41506edd378417dcf109f180d671e236d2f802059a72da0477219d"
+      "data": "0xaab2b27b1918b7237d98a0cdd092d67f9eafe3071d4c01a426b1c44ab14980a5",
+      "salt": "0x59f835d56d5741f608f46ae3c6925e550a7e6c378a1aa9dd39a8789f7efd46d6"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x4d0d9fbb95a6be96133dd8dc9ca423ad94d8ff26eca1e7fb8fde8c084bb675ca",
-      "s": "0x3d92fcdc88f43c50bec9f10f1092ae93708408d04f66ef2a2e7bff36ae2191f8"
+      "v": 28,
+      "r": "0xabfe474449c2908d2c31fc4485607724577f75380a4418c4433c16ab44981e57",
+      "s": "0x32c370547bf9c5c6d651488c69399d7d5f2cc933d85e0e115507ad0f2b94836b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDCrwa.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDCrwa.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xb284f891a213eb90f278321882dcdabab2622586b311f12bc47b49a28c62630c",
+    "uid": "0xa6d2cf4f46442d69ee93e003149518c6dcae3037c96b501a459aedf7ba8d433e",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x66ea4ba10f4e4fe7bf001b43b5886bd1c5e620c55da7e0d7399fe07221b6992a",
-      "salt": "0xcfd87e267f7cd34b3f2175f4c132bcf9c04e4bd8372ed51c19eb222f2f0e48f1"
+      "data": "0x732e4b1c24eb1e5ec9763343f7ab9203d4393fa0e5244f777108622f4e20c1ac",
+      "salt": "0xb64e93b54ef670bf168bf8c310b64141ddaa77a358360fd72a80b1c4bd40ff85"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xb7111207f3fd968229ff6fed5db652a3fb95383b87ea3e8fb4f23cc227a48f61",
-      "s": "0x2e68f2bc3f94d0100d1dda710192479472a5b311d0ebf8210256d031018d7084"
+      "v": 28,
+      "r": "0xe6d99bae629c9f37d340ddc252ffd72e34abb98d82c4a4baa7e7a00e488f0b58",
+      "s": "0x75c7db43f8c970ea9b72d7ca35d5e5fb02d445e36fe006ca24aef0ed6253dc75"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDM.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDM.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xcd55e02457ad033da51dc42faeef16ebf45d50d2a53f743d57c316593c2c62e7",
+    "uid": "0xc6c3c6ee70ccc71a823524d17621e028d555f41b996b96f8ddc3e2d97212252c",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xde12ef82bc8bbcd80cce1a572f24818db38e104d36d19b4fe7e9dd0f9c874bc4",
-      "salt": "0x0dd7b30b2506f6febbf5d5a9788369096c10bedd48a6fc7fb7274b3f6c1c1b83"
+      "data": "0x0112d0c55a5153b7a62479c65a64e32e477cb47221dfd941a2f9696d17ec7254",
+      "salt": "0xee8f5c1d8ed568cfd4492a89039f640868afda608eba3982e6c488e5ef0916b7"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x1093c791f5a5d912595b39a39651ad5dbb0a4e9e169de48ae2d766f58a1bb30c",
-      "s": "0x2b519fb329d3005784b6709adf418bfa5d917ebecaffd4245e584bad30a4b6c2"
+      "v": 27,
+      "r": "0x586b97277c4e81ed124faf14291213a927cec1ef78a3d1c772e639486d924b27",
+      "s": "0x4d16d999af88e561fe2e4d2178ff1f348c2ce6bce0a9bd32844b28b692edcdbd"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDQ.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDQ.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x8a0954cc94c919f9932f1a0447c1cb698568964088e57398dc537ab6f4a12d4e",
+    "uid": "0x5324558f20ccbb62927b31288fba3c318c390b6c59674144ad28d7da82836449",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x5dfa677c4a7102fdd03fd0d4198cb797fa4bd85d9136f846352f37fc7d7bedf3",
-      "salt": "0x7157d3ae4f98059663ade6a8e54a6e5bd3398ff9811fc9eea4d5af5192d9a428"
+      "data": "0xbd1e07f1475d2b0df1fdff83acb58dfe6133b2da5ec4e1f897ba19b8f2b22a8d",
+      "salt": "0xc040d38c1724362a4edf16f0ff8fae33588014c829bcfd1cc6c5b5b4be68d62d"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xca38e28c144befc71242c3544d7e4366345041b3a4d0718e6aa9de07b0572173",
-      "s": "0x6e2411738f8c824f8b2ab8e281c1c320598483e86c180636ab5747d2625f5c82"
+      "v": 28,
+      "r": "0x8d23bba68a4bc241812d13541443ab9303ca8402e3d37b3db4c6c9c9c5a28e92",
+      "s": "0x2e2c30c9586052e4c9abf2efbe0e96422b21fd110a541450c1475606c39b8ebe"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDR.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x66842f6748e3a85bb828cb870d4098896065ce3ab6757a7efd22dba66d584c76",
+    "uid": "0x4561f83d1ddbc8f063a7d4f77244ee9aa75e82a99655764254dda35994a5f3be",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xbd40ce0c601ab993e9e92f16030287347003e39746a562fb38bd943624f4783c",
-      "salt": "0x5e04bbb5f8998d6994ca9551c6df0708aa99fb243b697f46c8d48104522e64cf"
+      "data": "0xe2d80c8f008be2834e03c8d42c8dfe54a766ed439a23b10bf7e278ce11d77da9",
+      "salt": "0x2533deed8baf2d018341025c30e90d1162d09a9c615a7e0cfcb49b9035977d1b"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0xfaef48112d89acbe2f56148b2fa0356411860df51c9fae01afff387bc0323371",
-      "s": "0x7e403cae673fad82a81f0c6abba2ba70ef4df6e8ec62ce02e6ae87d833d53cf3"
+      "v": 28,
+      "r": "0x4fa431fbc4c78217af1fcd1998dc0500ff2baf2b4fceb4d82f20bcedebac9950",
+      "s": "0x54f82e190c5e5b20abc333f04c65c329268ac293a6c7b9f8224693b8091d2906"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDT.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x199c94d73333cb01bbd3e3e744492219d4d0a04a1e1591668e4d4c1672638957",
+    "uid": "0xe316e18c13a7596b317e0c5a7751172e13d910fa4e5a9c15161685ab6e005b8c",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0xe04b680011d68fcbcca1c7cdec7a5e498b31417e8ad5a005498a27149a215acc",
-      "salt": "0xdd539587997776e8fc925184b16e62201a6bf0d112dd96ab88e3568da2297968"
+      "data": "0xdef2ae608228d7964adfd3c9750cf0c63e8bc2e2a956d0e7f7e339282549b405",
+      "salt": "0x62693ee1552c7132c82e0c86ef3c83650047bef01b3e838ca1bee8c46be9bd31"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xc3b73222e1f83ed97f7a244284f842f565762de431c79449c8e05a3506287dfb",
-      "s": "0x3b49eb31bae1b14e27e6682cfffc511f32d7cb1821bcbfbcaeb6128fec432076"
+      "r": "0xd9b4c9ec2ac3da1996bc8a9cee779f0fe0aca2b7373ed188682f8e1f3e09700d",
+      "s": "0x47b2ed815bec339bbcaf5a4e10a2125179ec1427a2d80176d2c818a0827016cc"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDTlite.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakUSDTlite.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0xa3b51ffbb51f560b4bd0e64f57fbc526a64018948f9ef409d2c526b03eb3d06c",
+    "uid": "0x180fcbfbe09339cfd220cab61e83fdc2d23af4e0e4c13b5aa9563f4879df050b",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x707bcb687c6d33d6d63909114f7bae1bede41383f3fc628a361d62d38a911e28",
-      "salt": "0xab2beb51f757711c3327f7e84eb5838bfc187d920d5153f40c1ad6831411b8e8"
+      "data": "0xd6d6364979f5083daff38043f7d02f3a77e280562efb1be5eef99dcb092b0fe2",
+      "salt": "0x20492c7aefbc9d17e4e0a512bbc24c5743afaf393ccdbc84a599b506cb89a44a"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x649ff5b6964d6c0405efc209455b213427a60f17ee083ad33f67b2e947cdbc0d",
-      "s": "0x59db9144a3618cb5ecf7b25fc44bb867ba3f9165c6d04101381a12353453d6d5"
+      "v": 28,
+      "r": "0x68a771fdb1f237139c9feba32804991af463807c188dadfd6f44883807121a4d",
+      "s": "0x4cb19abfc022bfb070f66df64776393674111e8127a1d16ea07f63ad300a4479"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/morpho/sigs/calldata-steakhouse_financial-steakWBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/morpho/sigs/calldata-steakhouse_financial-steakWBTC.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x484cc59a833f9b1ff99d4982d6c4d428f5f173884f15437aeb5dd4864f1a1d8a",
+    "uid": "0x5ed0541563bc95e6d268128387c548987458c5515af6cbed8546b12258ddc6f6",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x88126234de459bb206e2e127005fd60e0ba0afb4dd5bb621643ca58dc58ab7de",
-      "salt": "0x73a753d934040e36e20be5fbfeb73fbdf9f87e362e9b899f140dccb0dcd3a66b"
+      "data": "0xeb4da53c091a53da6e454d76ce5ab5c574ef66f672d6e3018d2acbb52a1d1377",
+      "salt": "0x1eaa0c5df9583f2a79392cf7a82d0dd1bc9535af6a53d05aea9e3cd18e8948cc"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 27,
-      "r": "0x23455de79ab92986d93d89d36e5d0b0563ceda995e30ee073835e238402574d2",
-      "s": "0x7e7f3dc678d56b87eaffe29192401c20a969e83f1626964120d59a4600c8face"
+      "v": 28,
+      "r": "0xd4da5e8ee9b5e6c06b8a2fbe78c6248afcdb8fdccb3ad8edce66d24dda25b30a",
+      "s": "0x5eda5b99f372f7907b40549cca310deea818efb365ca948baae8af454df494f3"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/safe/sigs/calldata-SafeMigration-1.4.1.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/safe/sigs/calldata-SafeMigration-1.4.1.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x4312b9890abf51ae5fa01c65e96a4ffd7af4e0a16e7ebdf8628e51e0e96af2ed",
+    "uid": "0x299fbca90ec46f69ad354932fa9814157111e050ce8c68771f34b75fb86f96bb",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x8b3aaa8c1e8ccf029d1babf46fc309cfa837e4fc97634cdc80f1205448824165",
-      "salt": "0x0c0786d82b9aa7e25aa1dfd8f648ef8ac210a8a3f79681fd1bb234fbc2651007"
+      "data": "0x4cae1cf08110038ba8a127e4675aa7454c99fa6a6fd75443b695e1afd64e94c7",
+      "salt": "0xee1e9e0ebdc29ead8752b5f286b1412247f3a67c42e0f8b6d8a557fd891dc5f4"
     },
     "types": {
       "Attest": [
@@ -62,8 +62,8 @@
     },
     "signature": {
       "v": 27,
-      "r": "0xdf9bccc4e9f3a251dd3dfd078b0bf55e51dde55bfb7ba20e8460694bed1e8c3b",
-      "s": "0x76faca245f538d9e1e7c6e1abde7270b98b9b10dd07ccb5ad76b73fe198b5e99"
+      "r": "0xff73fdf2674577c85dc4cf48850e02dfae4c08902ccd5c7fed52d31e18dfdf04",
+      "s": "0x2f39b5f8a984773330fd71a7f23ce15bc6aa78f80be1029cfbff9ea2fb57e81b"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"

--- a/registry/safe/sigs/calldata-SafeMigration-1.5.0.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
+++ b/registry/safe/sigs/calldata-SafeMigration-1.5.0.eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6.json
@@ -1,7 +1,7 @@
 {
   "sig": {
     "version": 2,
-    "uid": "0x99473f5165960b7110ce0c42c062b3616105a852144d8cb2d4171547ac4b27dd",
+    "uid": "0x9a88f378df8430ed6978a095b5bb67db532ad6aea49506669ee2251534c2e45f",
     "domain": {
       "name": "EAS Attestation",
       "version": "0.26",
@@ -13,12 +13,12 @@
       "version": 2,
       "schema": "0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2",
       "recipient": "0x0000000000000000000000000000000000000000",
-      "time": "1785288536",
+      "time": "1788566693",
       "expirationTime": "0",
       "revocable": true,
       "refUID": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "data": "0x154b8dcaa9d056f78f384901448d34c33389861ab4fe703103cd0c5abd02a168",
-      "salt": "0x7e15298a1db50edffd2af4cac4972f0b863f9abeb3802a049a1e2e36e71f3a19"
+      "data": "0xc8f5f179438fd9b2e38682c7632f0cd4b28adc0bf8e25b4e5c32eda1962091ba",
+      "salt": "0x2c25667602438315ce668f57b50f4f3f189af57875d3746dc2496c8b4f87214f"
     },
     "types": {
       "Attest": [
@@ -61,9 +61,9 @@
       ]
     },
     "signature": {
-      "v": 28,
-      "r": "0x5839b5cbd01250c751e189a0e21ee605a95c5e10fb940c7933a824ebd5bc9ec1",
-      "s": "0x6b882f3fc2834ba58953b9cc4131e2e73a53b8f5a281c3b2560489e48d566dec"
+      "v": 27,
+      "r": "0x817be6d757bd435457ec9f27b45f8e972b95d41b25c9110b1a6d71ed3919644d",
+      "s": "0x131e610b1eb1a43ce7827a60f03ee9ac00017175e0301ab5ef07d7149ba3105e"
     }
   },
   "signer": "0x3846c3A30E62075Fa916216b35EF04B8F53931f6"


### PR DESCRIPTION
Replaces the 135 Cyfrin EAS offchain attestations whose descriptors use `includes`, correcting the descriptor hash carried by each attestation.

### Why

These 135 attestations were originally signed over the parsed root descriptor before `includes` was resolved. ERC-8176 requires the hash to cover the fully resolved descriptor. The original hashes therefore committed to the `includes` path strings, but not to the referenced included content, and do not match what a conforming verifier recomputes.

The hashing defect and correction are documented here:

- Report: Cyfrin/clearsig#16
- Fix: Cyfrin/clearsig#18, released as clearsig v0.4.0

The 46 attestations for descriptors without `includes` are unaffected because their file-as-written and resolved hashes are identical. Those files are not changed by this PR.

### What changed

Exactly 135 signature files are modified. No descriptors, tooling, indexes, or other files change.

- 2 1inch
- 27 Kiln
- 104 Morpho
- 2 Safe
- Attester unchanged: `0x3846c3A30E62075Fa916216b35EF04B8F53931f6` (auditor profile #2764, original attestations #2765)
- Schema unchanged: `0xe023eef113c1670774801c34b377fdf612dd8a4d2fa92fe382e15bd91fafb5c2`
- Each `message.data` is now the resolved ERC-8176 descriptor hash
- `recipient`, `expirationTime`, `revocable`, and `refUID` are unchanged
- `uid`, `salt`, `time`, and `signature` are new

### Verification

All 135 replacements were independently checked:

- Each package passes the official EAS SDK verification, including UID recomputation.
- Independent EIP-712 recovery with ethers returns the attester address recorded in the filename and package.
- Each `message.data` matches both clearsig v0.4.0 and a separately written recursive include resolver.
- Each root descriptor is byte-identical to its review-time lockfile snapshot.
- Each resolved hash matches its review-time lockfile and current `master`.
- All 181 attestations on the proposed branch verify against current `master`; the 46 unaffected signature files remain byte-identical to upstream.

Example: 1inch `calldata-AggregationRouterV4` changes from `0xd55e8bf5…b57c4cc` (unresolved) to `0x0039d2cc…a7d923fc` (resolved).

### Superseded attestations

The 135 superseded offchain UIDs are non-expiring and have not yet been revoked onchain. This PR removes them from the current registry distribution. The separate onchain-revocation decision is recorded in Cyfrin/clearsig#16.