### PR TITLE
feat: cryptopunks clear signing

### DIFF
--- a/registry/cryptopunks/calldata-CryptoPunks721.json
+++ b/registry/cryptopunks/calldata-CryptoPunks721.json
@@ -20,14 +20,26 @@
         "interpolatedIntent": "Wrap Punk #{#.punkIndex}",
         "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
       },
-      "wrapPunkBatch(uint256[] punkIndexes)": { "intent": "Wrap Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
+      "wrapPunkBatch(uint256[] punkIndexes)": {
+        "intent": "Wrap Punks",
+        "interpolatedIntent": "Wrap Punks #{#.punkIndexes.[]} as ERC-721s",
+        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+      },
       "unwrapPunk(uint256 punkIndex)": {
         "intent": "Unwrap Punk",
         "interpolatedIntent": "Unwrap Punk #{#.punkIndex}",
         "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
       },
-      "unwrapPunkBatch(uint256[] punkIndexes)": { "intent": "Unwrap Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
-      "migrateLegacyWrappedPunks(uint256[] punkIndexes)": { "intent": "Migrate Legacy Wrapped Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
+      "unwrapPunkBatch(uint256[] punkIndexes)": {
+        "intent": "Unwrap Punks",
+        "interpolatedIntent": "Unwrap Punks #{#.punkIndexes.[]} back to the original contract",
+        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+      },
+      "migrateLegacyWrappedPunks(uint256[] punkIndexes)": {
+        "intent": "Migrate Legacy Wrapped Punks",
+        "interpolatedIntent": "Migrate legacy wrapped Punks #{#.punkIndexes.[]} to CryptoPunks 721",
+        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+      },
       "rescuePunk(uint256 punkIndex)": {
         "intent": "Rescue Punk",
         "interpolatedIntent": "Rescue Punk #{#.punkIndex}",
@@ -43,6 +55,7 @@
       },
       "setApprovalForAll(address operator, bool isApproved)": {
         "intent": "Set Operator Approval",
+        "interpolatedIntent": "Set {#.operator} as operator for all your wrapped Punks: {#.isApproved}",
         "fields": [
           { "path": "#.operator", "label": "Operator", "$ref": "$.display.definitions.account" },
           { "path": "#.isApproved", "label": "Approved", "format": "raw" }

--- a/registry/cryptopunks/calldata-CryptoPunks721.json
+++ b/registry/cryptopunks/calldata-CryptoPunks721.json
@@ -18,7 +18,7 @@
       },
       "wrapPunkBatch(uint256[] punkIndexes)": {
         "intent": "Wrap Punks",
-        "interpolatedIntent": "Wrap Punks #{#.punkIndexes.[]} as ERC-721s",
+        "interpolatedIntent": "Wrap the selected Punks as ERC-721s",
         "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "unwrapPunk(uint256 punkIndex)": {
@@ -28,12 +28,12 @@
       },
       "unwrapPunkBatch(uint256[] punkIndexes)": {
         "intent": "Unwrap Punks",
-        "interpolatedIntent": "Unwrap Punks #{#.punkIndexes.[]} back to the original contract",
+        "interpolatedIntent": "Unwrap the selected Punks back to the original contract",
         "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "migrateLegacyWrappedPunks(uint256[] punkIndexes)": {
         "intent": "Migrate Legacy Wrapped Punks",
-        "interpolatedIntent": "Migrate legacy wrapped Punks #{#.punkIndexes.[]} to CryptoPunks 721",
+        "interpolatedIntent": "Migrate the selected legacy wrapped Punks to CryptoPunks 721",
         "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "rescuePunk(uint256 punkIndex)": {

--- a/registry/cryptopunks/calldata-CryptoPunks721.json
+++ b/registry/cryptopunks/calldata-CryptoPunks721.json
@@ -10,54 +10,60 @@
     "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:35Z" }
   },
   "display": {
-    "definitions": {
-      "punk": { "label": "Punk", "format": "raw" },
-      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } }
-    },
     "formats": {
       "wrapPunk(uint256 punkIndex)": {
         "intent": "Wrap Punk",
         "interpolatedIntent": "Wrap Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "wrapPunkBatch(uint256[] punkIndexes)": {
         "intent": "Wrap Punks",
         "interpolatedIntent": "Wrap Punks #{#.punkIndexes.[]} as ERC-721s",
-        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "unwrapPunk(uint256 punkIndex)": {
         "intent": "Unwrap Punk",
         "interpolatedIntent": "Unwrap Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "unwrapPunkBatch(uint256[] punkIndexes)": {
         "intent": "Unwrap Punks",
         "interpolatedIntent": "Unwrap Punks #{#.punkIndexes.[]} back to the original contract",
-        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "migrateLegacyWrappedPunks(uint256[] punkIndexes)": {
         "intent": "Migrate Legacy Wrapped Punks",
         "interpolatedIntent": "Migrate legacy wrapped Punks #{#.punkIndexes.[]} to CryptoPunks 721",
-        "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndexes.[]", "label": "Punk", "format": "raw" }]
       },
       "rescuePunk(uint256 punkIndex)": {
         "intent": "Rescue Punk",
         "interpolatedIntent": "Rescue Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "approve(address account, uint256 id)": {
         "intent": "Approve Punk Transfer",
         "interpolatedIntent": "Approve Punk #{#.id}",
         "fields": [
-          { "path": "#.id", "$ref": "$.display.definitions.punk" },
-          { "path": "#.account", "label": "Approved Address", "$ref": "$.display.definitions.account" }
+          { "path": "#.id", "label": "Punk", "format": "raw" },
+          {
+            "path": "#.account",
+            "label": "Approved Address",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
         ]
       },
       "setApprovalForAll(address operator, bool isApproved)": {
         "intent": "Set Operator Approval",
         "interpolatedIntent": "Set {#.operator} as operator for all your wrapped Punks: {#.isApproved}",
         "fields": [
-          { "path": "#.operator", "label": "Operator", "$ref": "$.display.definitions.account" },
+          {
+            "path": "#.operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.isApproved", "label": "Approved", "format": "raw" }
         ]
       },
@@ -65,27 +71,57 @@
         "intent": "Transfer Wrapped Punk",
         "interpolatedIntent": "Transfer Punk #{#.id}",
         "fields": [
-          { "path": "#.id", "$ref": "$.display.definitions.punk" },
-          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
-          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+          { "path": "#.id", "label": "Punk", "format": "raw" },
+          {
+            "path": "#.from",
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "#.to",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
         ]
       },
       "safeTransferFrom(address from, address to, uint256 id)": {
         "intent": "Transfer Wrapped Punk",
         "interpolatedIntent": "Transfer Punk #{#.id}",
         "fields": [
-          { "path": "#.id", "$ref": "$.display.definitions.punk" },
-          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
-          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+          { "path": "#.id", "label": "Punk", "format": "raw" },
+          {
+            "path": "#.from",
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "#.to",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
         ]
       },
       "safeTransferFrom(address from, address to, uint256 id, bytes data)": {
         "intent": "Transfer Wrapped Punk",
         "interpolatedIntent": "Transfer Punk #{#.id}",
         "fields": [
-          { "path": "#.id", "$ref": "$.display.definitions.punk" },
-          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
-          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" },
+          { "path": "#.id", "label": "Punk", "format": "raw" },
+          {
+            "path": "#.from",
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "#.to",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.data", "label": "Data", "format": "raw", "visible": "never" }
         ]
       }

--- a/registry/cryptopunks/calldata-CryptoPunks721.json
+++ b/registry/cryptopunks/calldata-CryptoPunks721.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "CryptoPunks721",
+    "contract": { "deployments": [{ "chainId": 1, "address": "0x000000000000003607fce1aC9e043a86675C5C2F" }] }
+  },
+  "metadata": {
+    "owner": "CryptoPunks",
+    "contractName": "CryptoPunks 721",
+    "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:35Z" }
+  },
+  "display": {
+    "definitions": {
+      "punk": { "label": "Punk", "format": "raw" },
+      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } }
+    },
+    "formats": {
+      "wrapPunk(uint256 punkIndex)": {
+        "intent": "Wrap Punk",
+        "interpolatedIntent": "Wrap Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "wrapPunkBatch(uint256[] punkIndexes)": { "intent": "Wrap Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
+      "unwrapPunk(uint256 punkIndex)": {
+        "intent": "Unwrap Punk",
+        "interpolatedIntent": "Unwrap Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "unwrapPunkBatch(uint256[] punkIndexes)": { "intent": "Unwrap Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
+      "migrateLegacyWrappedPunks(uint256[] punkIndexes)": { "intent": "Migrate Legacy Wrapped Punks", "fields": [{ "path": "#.punkIndexes.[]", "$ref": "$.display.definitions.punk" }] },
+      "rescuePunk(uint256 punkIndex)": {
+        "intent": "Rescue Punk",
+        "interpolatedIntent": "Rescue Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "approve(address account, uint256 id)": {
+        "intent": "Approve Punk Transfer",
+        "interpolatedIntent": "Approve Punk #{#.id}",
+        "fields": [
+          { "path": "#.id", "$ref": "$.display.definitions.punk" },
+          { "path": "#.account", "label": "Approved Address", "$ref": "$.display.definitions.account" }
+        ]
+      },
+      "setApprovalForAll(address operator, bool isApproved)": {
+        "intent": "Set Operator Approval",
+        "fields": [
+          { "path": "#.operator", "label": "Operator", "$ref": "$.display.definitions.account" },
+          { "path": "#.isApproved", "label": "Approved", "format": "raw" }
+        ]
+      },
+      "transferFrom(address from, address to, uint256 id)": {
+        "intent": "Transfer Wrapped Punk",
+        "interpolatedIntent": "Transfer Punk #{#.id}",
+        "fields": [
+          { "path": "#.id", "$ref": "$.display.definitions.punk" },
+          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
+          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+        ]
+      },
+      "safeTransferFrom(address from, address to, uint256 id)": {
+        "intent": "Transfer Wrapped Punk",
+        "interpolatedIntent": "Transfer Punk #{#.id}",
+        "fields": [
+          { "path": "#.id", "$ref": "$.display.definitions.punk" },
+          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
+          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+        ]
+      },
+      "safeTransferFrom(address from, address to, uint256 id, bytes data)": {
+        "intent": "Transfer Wrapped Punk",
+        "interpolatedIntent": "Transfer Punk #{#.id}",
+        "fields": [
+          { "path": "#.id", "$ref": "$.display.definitions.punk" },
+          { "path": "#.from", "label": "From", "$ref": "$.display.definitions.account" },
+          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" },
+          { "path": "#.data", "label": "Data", "format": "raw", "visible": "never" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/cryptopunks/calldata-CryptoPunksMarket.json
+++ b/registry/cryptopunks/calldata-CryptoPunksMarket.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "CryptoPunksMarket",
+    "contract": { "deployments": [{ "chainId": 1, "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" }] }
+  },
+  "metadata": {
+    "owner": "CryptoPunks",
+    "contractName": "CryptoPunksMarket",
+    "info": { "url": "https://cryptopunks.app", "deploymentDate": "2017-06-22T19:40:00Z" }
+  },
+  "display": {
+    "definitions": {
+      "punk": { "label": "Punk", "format": "raw" },
+      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } }
+    },
+    "formats": {
+      "buyPunk(uint256 punkIndex)": {
+        "intent": "Buy Punk",
+        "interpolatedIntent": "Buy Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }, { "path": "@.value", "label": "Price", "format": "amount" }]
+      },
+      "enterBidForPunk(uint256 punkIndex)": {
+        "intent": "Bid on Punk",
+        "interpolatedIntent": "Bid on Punk #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "@.value", "label": "Bid Amount", "format": "amount" }
+        ]
+      },
+      "withdrawBidForPunk(uint256 punkIndex)": {
+        "intent": "Withdraw Bid",
+        "interpolatedIntent": "Withdraw Bid on #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "acceptBidForPunk(uint256 punkIndex, uint256 minPrice)": {
+        "intent": "Accept Bid",
+        "interpolatedIntent": "Accept Bid on #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.minPrice", "label": "Minimum Price", "format": "amount" }
+        ]
+      },
+      "offerPunkForSale(uint256 punkIndex, uint256 minSalePriceInWei)": {
+        "intent": "List Punk for Sale",
+        "interpolatedIntent": "List Punk #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.minSalePriceInWei", "label": "Price", "format": "amount" }
+        ]
+      },
+      "offerPunkForSaleToAddress(uint256 punkIndex, uint256 minSalePriceInWei, address toAddress)": {
+        "intent": "List Punk for Private Sale",
+        "interpolatedIntent": "Offer Punk #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.minSalePriceInWei", "label": "Price", "format": "amount" },
+          { "path": "#.toAddress", "label": "Buyer", "$ref": "$.display.definitions.account" }
+        ]
+      },
+      "punkNoLongerForSale(uint256 punkIndex)": {
+        "intent": "Remove Punk Listing",
+        "interpolatedIntent": "Delist Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "transferPunk(address to, uint256 punkIndex)": {
+        "intent": "Transfer Punk",
+        "interpolatedIntent": "Transfer Punk #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+        ]
+      },
+      "withdraw()": { "intent": "Withdraw ETH Balance", "fields": [] },
+      "getPunk(uint256 punkIndex)": {
+        "intent": "Claim Punk",
+        "interpolatedIntent": "Claim Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      }
+    }
+  }
+}

--- a/registry/cryptopunks/calldata-CryptoPunksMarket.json
+++ b/registry/cryptopunks/calldata-CryptoPunksMarket.json
@@ -71,7 +71,11 @@
           { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
         ]
       },
-      "withdraw()": { "intent": "Withdraw ETH Balance", "fields": [] },
+      "withdraw()": {
+        "intent": "Withdraw ETH Balance",
+        "interpolatedIntent": "Withdraw your ETH balance from the CryptoPunks market",
+        "fields": []
+      },
       "getPunk(uint256 punkIndex)": {
         "intent": "Claim Punk",
         "interpolatedIntent": "Claim Punk #{#.punkIndex}",

--- a/registry/cryptopunks/calldata-CryptoPunksMarket.json
+++ b/registry/cryptopunks/calldata-CryptoPunksMarket.json
@@ -10,34 +10,30 @@
     "info": { "url": "https://cryptopunks.app", "deploymentDate": "2017-06-22T19:40:00Z" }
   },
   "display": {
-    "definitions": {
-      "punk": { "label": "Punk", "format": "raw" },
-      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } }
-    },
     "formats": {
       "buyPunk(uint256 punkIndex)": {
         "intent": "Buy Punk",
         "interpolatedIntent": "Buy Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }, { "path": "@.value", "label": "Price", "format": "amount" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }, { "path": "@.value", "label": "Price", "format": "amount" }]
       },
       "enterBidForPunk(uint256 punkIndex)": {
         "intent": "Bid on Punk",
         "interpolatedIntent": "Bid on Punk #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
           { "path": "@.value", "label": "Bid Amount", "format": "amount" }
         ]
       },
       "withdrawBidForPunk(uint256 punkIndex)": {
         "intent": "Withdraw Bid",
         "interpolatedIntent": "Withdraw Bid on #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "acceptBidForPunk(uint256 punkIndex, uint256 minPrice)": {
         "intent": "Accept Bid",
         "interpolatedIntent": "Accept Bid on #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
           { "path": "#.minPrice", "label": "Minimum Price", "format": "amount" }
         ]
       },
@@ -45,7 +41,7 @@
         "intent": "List Punk for Sale",
         "interpolatedIntent": "List Punk #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
           { "path": "#.minSalePriceInWei", "label": "Price", "format": "amount" }
         ]
       },
@@ -53,22 +49,32 @@
         "intent": "List Punk for Private Sale",
         "interpolatedIntent": "Offer Punk #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
           { "path": "#.minSalePriceInWei", "label": "Price", "format": "amount" },
-          { "path": "#.toAddress", "label": "Buyer", "$ref": "$.display.definitions.account" }
+          {
+            "path": "#.toAddress",
+            "label": "Buyer",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
         ]
       },
       "punkNoLongerForSale(uint256 punkIndex)": {
         "intent": "Remove Punk Listing",
         "interpolatedIntent": "Delist Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "transferPunk(address to, uint256 punkIndex)": {
         "intent": "Transfer Punk",
         "interpolatedIntent": "Transfer Punk #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
-          { "path": "#.to", "label": "Recipient", "$ref": "$.display.definitions.account" }
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
+          {
+            "path": "#.to",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
         ]
       },
       "withdraw()": {
@@ -79,7 +85,7 @@
       "getPunk(uint256 punkIndex)": {
         "intent": "Claim Punk",
         "interpolatedIntent": "Claim Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       }
     }
   }

--- a/registry/cryptopunks/calldata-Stash.json
+++ b/registry/cryptopunks/calldata-Stash.json
@@ -16,15 +16,6 @@
     "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:47Z" }
   },
   "display": {
-    "definitions": {
-      "punk": { "label": "Punk", "format": "raw" },
-      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } },
-      "collection": {
-        "label": "Collection",
-        "format": "addressName",
-        "params": { "types": ["collection", "contract"], "sources": ["local", "ens"] }
-      }
-    },
     "formats": {
       "withdraw(address tokenAddress, uint256 amount)": {
         "intent": "Withdraw from Stash",
@@ -41,13 +32,18 @@
       "withdrawPunks(uint256[] tokenIds)": {
         "intent": "Withdraw Punks from Stash",
         "interpolatedIntent": "Withdraw Punks #{#.tokenIds.[]} from your Stash",
-        "fields": [{ "path": "#.tokenIds.[]", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.tokenIds.[]", "label": "Punk", "format": "raw" }]
       },
       "withdrawERC721(address tokenAddress, uint256[] tokenIds)": {
         "intent": "Withdraw NFTs from Stash",
         "interpolatedIntent": "Withdraw {#.tokenIds.[]} from your Stash",
         "fields": [
-          { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
+          {
+            "path": "#.tokenAddress",
+            "label": "Collection",
+            "format": "addressName",
+            "params": { "types": ["collection", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.tokenIds.[]", "label": "Token", "format": "nftName", "params": { "collectionPath": "#.tokenAddress" } }
         ]
       },
@@ -55,7 +51,12 @@
         "intent": "Withdraw ERC-1155 Tokens",
         "interpolatedIntent": "Withdraw {#.amounts.[]} of token {#.tokenIds.[]} from {#.tokenAddress} out of your Stash",
         "fields": [
-          { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
+          {
+            "path": "#.tokenAddress",
+            "label": "Collection",
+            "format": "addressName",
+            "params": { "types": ["collection", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.tokenIds.[]", "label": "Token ID", "format": "raw" },
           { "path": "#.amounts.[]", "label": "Amount", "format": "raw" }
         ]
@@ -70,7 +71,7 @@
         "intent": "Accept Punk Bid",
         "interpolatedIntent": "Sell Punk #{#.punkIndex}",
         "fields": [
-          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.punkIndex", "label": "Punk", "format": "raw" },
           { "path": "#.bid.order.pricePerUnit", "label": "Sale Price", "format": "amount" },
           { "path": "#.bid.expiration", "label": "Bid Expiration", "format": "date", "params": { "encoding": "timestamp" } },
           {
@@ -107,12 +108,19 @@
       "wrapPunk(uint256 punkIndex)": {
         "intent": "Wrap Punk from Stash",
         "interpolatedIntent": "Wrap Punk #{#.punkIndex}",
-        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+        "fields": [{ "path": "#.punkIndex", "label": "Punk", "format": "raw" }]
       },
       "initialize(address _owner)": {
         "intent": "Initialize Stash",
         "interpolatedIntent": "Initialize this Stash with {#._owner} as owner",
-        "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
+        "fields": [
+          {
+            "path": "#._owner",
+            "label": "Stash Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
+        ]
       }
     }
   }

--- a/registry/cryptopunks/calldata-Stash.json
+++ b/registry/cryptopunks/calldata-Stash.json
@@ -31,12 +31,12 @@
       },
       "withdrawPunks(uint256[] tokenIds)": {
         "intent": "Withdraw Punks from Stash",
-        "interpolatedIntent": "Withdraw Punks #{#.tokenIds.[]} from your Stash",
+        "interpolatedIntent": "Withdraw the selected Punks from your Stash",
         "fields": [{ "path": "#.tokenIds.[]", "label": "Punk", "format": "raw" }]
       },
       "withdrawERC721(address tokenAddress, uint256[] tokenIds)": {
         "intent": "Withdraw NFTs from Stash",
-        "interpolatedIntent": "Withdraw {#.tokenIds.[]} from your Stash",
+        "interpolatedIntent": "Withdraw NFTs from {#.tokenAddress} out of your Stash",
         "fields": [
           {
             "path": "#.tokenAddress",
@@ -49,7 +49,7 @@
       },
       "withdrawERC1155(address tokenAddress, uint256[] tokenIds, uint256[] amounts)": {
         "intent": "Withdraw ERC-1155 Tokens",
-        "interpolatedIntent": "Withdraw {#.amounts.[]} of token {#.tokenIds.[]} from {#.tokenAddress} out of your Stash",
+        "interpolatedIntent": "Withdraw ERC-1155 tokens from {#.tokenAddress} out of your Stash",
         "fields": [
           {
             "path": "#.tokenAddress",
@@ -80,7 +80,7 @@
             "format": "addressName",
             "params": { "types": ["contract"], "sources": ["local", "ens"] }
           },
-          { "path": "#.bid.order.numberOfUnits", "label": "Quantity", "format": "raw", "visible": { "ifNotIn": [1] } },
+          { "path": "#.bid.order.numberOfUnits", "label": "Quantity", "format": "raw" },
           { "path": "#.bid.accountNonce", "label": "Account Nonce", "format": "raw", "visible": "never" },
           { "path": "#.bid.bidNonce", "label": "Bid ID", "format": "raw", "visible": "never" },
           { "path": "#.bid.root", "label": "Punk Set Root", "format": "raw", "visible": "never" },

--- a/registry/cryptopunks/calldata-Stash.json
+++ b/registry/cryptopunks/calldata-Stash.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "Stash",
+    "contract": {
+      "deployments": [{ "chainId": 1, "address": "0x00000000000060D035a8002956B5fb02e3968eec" }],
+      "factory": {
+        "deployments": [{ "chainId": 1, "address": "0x000000000000A6fA31F5fC51c1640aAc76866750" }],
+        "deployEvent": "Deployed(address,address)"
+      }
+    }
+  },
+  "metadata": {
+    "owner": "CryptoPunks",
+    "contractName": "Stash",
+    "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:47Z" }
+  },
+  "display": {
+    "definitions": {
+      "punk": { "label": "Punk", "format": "raw" },
+      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } },
+      "collection": {
+        "label": "Collection",
+        "format": "addressName",
+        "params": { "types": ["collection", "contract"], "sources": ["local", "ens"] }
+      }
+    },
+    "formats": {
+      "withdraw(address tokenAddress, uint256 amount)": {
+        "intent": "Withdraw from Stash",
+        "interpolatedIntent": "Withdraw {#.amount}",
+        "fields": [
+          {
+            "path": "#.amount",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "#.tokenAddress", "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000" }
+          }
+        ]
+      },
+      "withdrawPunks(uint256[] tokenIds)": { "intent": "Withdraw Punks from Stash", "fields": [{ "path": "#.tokenIds.[]", "$ref": "$.display.definitions.punk" }] },
+      "withdrawERC721(address tokenAddress, uint256[] tokenIds)": {
+        "intent": "Withdraw NFTs from Stash",
+        "fields": [
+          { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
+          { "path": "#.tokenIds.[]", "label": "Token", "format": "nftName", "params": { "collectionPath": "#.tokenAddress" } }
+        ]
+      },
+      "withdrawERC1155(address tokenAddress, uint256[] tokenIds, uint256[] amounts)": {
+        "intent": "Withdraw ERC-1155 Tokens",
+        "fields": [
+          { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
+          { "path": "#.tokenIds.[]", "label": "Token ID", "format": "raw" },
+          { "path": "#.amounts.[]", "label": "Amount", "format": "raw" }
+        ]
+      },
+      "cancelPunkBid(uint256 bidNonce)": { "intent": "Cancel Punk Bid", "fields": [{ "path": "#.bidNonce", "label": "Bid ID", "format": "raw" }] },
+      "cancelAllPunkBids()": { "intent": "Cancel All Punk Bids", "fields": [] },
+      "processPunkBid(((uint16 numberOfUnits, uint80 pricePerUnit, address auction) order, uint256 accountNonce, uint256 bidNonce, uint256 expiration, bytes32 root) bid, uint256 punkIndex, bytes signature, bytes32[] proof)": {
+        "intent": "Accept Punk Bid",
+        "interpolatedIntent": "Sell Punk #{#.punkIndex}",
+        "fields": [
+          { "path": "#.punkIndex", "$ref": "$.display.definitions.punk" },
+          { "path": "#.bid.order.pricePerUnit", "label": "Sale Price", "format": "amount" },
+          { "path": "#.bid.expiration", "label": "Bid Expiration", "format": "date", "params": { "encoding": "timestamp" } },
+          {
+            "path": "#.bid.order.auction",
+            "label": "Marketplace",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local", "ens"] }
+          },
+          { "path": "#.bid.order.numberOfUnits", "label": "Quantity", "format": "raw", "visible": { "ifNotIn": [1] } },
+          { "path": "#.bid.accountNonce", "label": "Account Nonce", "format": "raw", "visible": "never" },
+          { "path": "#.bid.bidNonce", "label": "Bid ID", "format": "raw", "visible": "never" },
+          { "path": "#.bid.root", "label": "Punk Set Root", "format": "raw", "visible": "never" },
+          { "path": "#.signature", "label": "Bid Signature", "format": "raw", "visible": "never" },
+          { "path": "#.proof.[]", "label": "Proof", "format": "raw", "visible": "never" }
+        ]
+      },
+      "placeOrder(uint80 pricePerUnit, uint16 numberOfUnits)": {
+        "intent": "Place Order",
+        "fields": [
+          { "path": "#.pricePerUnit", "label": "Price Per Unit", "format": "amount" },
+          { "path": "#.numberOfUnits", "label": "Quantity", "format": "raw" },
+          { "path": "@.value", "label": "Deposit", "format": "amount" }
+        ]
+      },
+      "processOrder(uint80 costPerUnit, uint16 numberOfUnits)": {
+        "intent": "Process Order",
+        "fields": [
+          { "path": "#.costPerUnit", "label": "Cost Per Unit", "format": "amount" },
+          { "path": "#.numberOfUnits", "label": "Quantity", "format": "raw" }
+        ]
+      },
+      "wrapPunk(uint256 punkIndex)": {
+        "intent": "Wrap Punk from Stash",
+        "interpolatedIntent": "Wrap Punk #{#.punkIndex}",
+        "fields": [{ "path": "#.punkIndex", "$ref": "$.display.definitions.punk" }]
+      },
+      "initialize(address _owner)": {
+        "intent": "Initialize Stash",
+        "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
+      }
+    }
+  }
+}

--- a/registry/cryptopunks/calldata-Stash.json
+++ b/registry/cryptopunks/calldata-Stash.json
@@ -38,9 +38,14 @@
           }
         ]
       },
-      "withdrawPunks(uint256[] tokenIds)": { "intent": "Withdraw Punks from Stash", "fields": [{ "path": "#.tokenIds.[]", "$ref": "$.display.definitions.punk" }] },
+      "withdrawPunks(uint256[] tokenIds)": {
+        "intent": "Withdraw Punks from Stash",
+        "interpolatedIntent": "Withdraw Punks #{#.tokenIds.[]} from your Stash",
+        "fields": [{ "path": "#.tokenIds.[]", "$ref": "$.display.definitions.punk" }]
+      },
       "withdrawERC721(address tokenAddress, uint256[] tokenIds)": {
         "intent": "Withdraw NFTs from Stash",
+        "interpolatedIntent": "Withdraw {#.tokenIds.[]} from your Stash",
         "fields": [
           { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
           { "path": "#.tokenIds.[]", "label": "Token", "format": "nftName", "params": { "collectionPath": "#.tokenAddress" } }
@@ -48,14 +53,19 @@
       },
       "withdrawERC1155(address tokenAddress, uint256[] tokenIds, uint256[] amounts)": {
         "intent": "Withdraw ERC-1155 Tokens",
+        "interpolatedIntent": "Withdraw {#.amounts.[]} of token {#.tokenIds.[]} from {#.tokenAddress} out of your Stash",
         "fields": [
           { "path": "#.tokenAddress", "$ref": "$.display.definitions.collection" },
           { "path": "#.tokenIds.[]", "label": "Token ID", "format": "raw" },
           { "path": "#.amounts.[]", "label": "Amount", "format": "raw" }
         ]
       },
-      "cancelPunkBid(uint256 bidNonce)": { "intent": "Cancel Punk Bid", "fields": [{ "path": "#.bidNonce", "label": "Bid ID", "format": "raw" }] },
-      "cancelAllPunkBids()": { "intent": "Cancel All Punk Bids", "fields": [] },
+      "cancelPunkBid(uint256 bidNonce)": {
+        "intent": "Cancel Punk Bid",
+        "interpolatedIntent": "Cancel Punk bid {#.bidNonce}",
+        "fields": [{ "path": "#.bidNonce", "label": "Bid ID", "format": "raw" }]
+      },
+      "cancelAllPunkBids()": { "intent": "Cancel All Punk Bids", "interpolatedIntent": "Cancel every open Punk bid from your Stash", "fields": [] },
       "processPunkBid(((uint16 numberOfUnits, uint80 pricePerUnit, address auction) order, uint256 accountNonce, uint256 bidNonce, uint256 expiration, bytes32 root) bid, uint256 punkIndex, bytes signature, bytes32[] proof)": {
         "intent": "Accept Punk Bid",
         "interpolatedIntent": "Sell Punk #{#.punkIndex}",
@@ -79,6 +89,7 @@
       },
       "placeOrder(uint80 pricePerUnit, uint16 numberOfUnits)": {
         "intent": "Place Order",
+        "interpolatedIntent": "Order {#.numberOfUnits} at {#.pricePerUnit} each, depositing {@.value}",
         "fields": [
           { "path": "#.pricePerUnit", "label": "Price Per Unit", "format": "amount" },
           { "path": "#.numberOfUnits", "label": "Quantity", "format": "raw" },
@@ -87,6 +98,7 @@
       },
       "processOrder(uint80 costPerUnit, uint16 numberOfUnits)": {
         "intent": "Process Order",
+        "interpolatedIntent": "Settle {#.numberOfUnits} at {#.costPerUnit} each",
         "fields": [
           { "path": "#.costPerUnit", "label": "Cost Per Unit", "format": "amount" },
           { "path": "#.numberOfUnits", "label": "Quantity", "format": "raw" }
@@ -99,6 +111,7 @@
       },
       "initialize(address _owner)": {
         "intent": "Initialize Stash",
+        "interpolatedIntent": "Initialize this Stash with {#._owner} as owner",
         "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
       }
     }

--- a/registry/cryptopunks/calldata-StashFactory.json
+++ b/registry/cryptopunks/calldata-StashFactory.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "StashFactory",
+    "contract": { "deployments": [{ "chainId": 1, "address": "0x000000000000A6fA31F5fC51c1640aAc76866750" }] }
+  },
+  "metadata": {
+    "owner": "CryptoPunks",
+    "contractName": "Stash Factory",
+    "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:35Z" }
+  },
+  "display": {
+    "definitions": {
+      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } },
+      "contractAddress": { "format": "addressName", "params": { "types": ["contract"], "sources": ["local", "ens"] } }
+    },
+    "formats": {
+      "deployStash(address _owner)": {
+        "intent": "Create Stash",
+        "interpolatedIntent": "Create Stash for {#._owner}",
+        "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
+      },
+      "upgradeStash()": { "intent": "Upgrade Stash", "fields": [] },
+      "setAuction(address auction, bool _isAuction)": {
+        "intent": "Set Marketplace Status",
+        "fields": [
+          { "path": "#.auction", "label": "Marketplace", "$ref": "$.display.definitions.contractAddress" },
+          { "path": "#._isAuction", "label": "Enabled", "format": "raw" }
+        ]
+      },
+      "addVersion(address implementation)": {
+        "intent": "Add Stash Implementation",
+        "fields": [{ "path": "#.implementation", "label": "Implementation", "$ref": "$.display.definitions.contractAddress" }]
+      },
+      "transferOwnership(address newOwner)": {
+        "intent": "Transfer Factory Ownership",
+        "fields": [{ "path": "#.newOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
+      },
+      "renounceOwnership()": { "intent": "Renounce Factory Ownership", "fields": [] },
+      "requestOwnershipHandover()": { "intent": "Request Ownership Handover", "fields": [] },
+      "completeOwnershipHandover(address pendingOwner)": {
+        "intent": "Complete Ownership Handover",
+        "fields": [{ "path": "#.pendingOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
+      },
+      "cancelOwnershipHandover()": { "intent": "Cancel Ownership Handover", "fields": [] },
+      "grantRoles(address user, uint256 roles)": {
+        "intent": "Grant Roles",
+        "fields": [
+          { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
+          { "path": "#.roles", "label": "Roles", "format": "raw" }
+        ]
+      },
+      "revokeRoles(address user, uint256 roles)": {
+        "intent": "Revoke Roles",
+        "fields": [
+          { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
+          { "path": "#.roles", "label": "Roles", "format": "raw" }
+        ]
+      },
+      "renounceRoles(uint256 roles)": { "intent": "Renounce Roles", "fields": [{ "path": "#.roles", "label": "Roles", "format": "raw" }] }
+    }
+  }
+}

--- a/registry/cryptopunks/calldata-StashFactory.json
+++ b/registry/cryptopunks/calldata-StashFactory.json
@@ -20,9 +20,10 @@
         "interpolatedIntent": "Create Stash for {#._owner}",
         "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
       },
-      "upgradeStash()": { "intent": "Upgrade Stash", "fields": [] },
+      "upgradeStash()": { "intent": "Upgrade Stash", "interpolatedIntent": "Upgrade your Stash to the latest version", "fields": [] },
       "setAuction(address auction, bool _isAuction)": {
         "intent": "Set Marketplace Status",
+        "interpolatedIntent": "Set marketplace {#.auction} enabled: {#._isAuction}",
         "fields": [
           { "path": "#.auction", "label": "Marketplace", "$ref": "$.display.definitions.contractAddress" },
           { "path": "#._isAuction", "label": "Enabled", "format": "raw" }
@@ -30,21 +31,33 @@
       },
       "addVersion(address implementation)": {
         "intent": "Add Stash Implementation",
+        "interpolatedIntent": "Add Stash implementation {#.implementation}",
         "fields": [{ "path": "#.implementation", "label": "Implementation", "$ref": "$.display.definitions.contractAddress" }]
       },
       "transferOwnership(address newOwner)": {
         "intent": "Transfer Factory Ownership",
+        "interpolatedIntent": "Transfer factory ownership to {#.newOwner}",
         "fields": [{ "path": "#.newOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
       },
-      "renounceOwnership()": { "intent": "Renounce Factory Ownership", "fields": [] },
-      "requestOwnershipHandover()": { "intent": "Request Ownership Handover", "fields": [] },
+      "renounceOwnership()": { "intent": "Renounce Factory Ownership", "interpolatedIntent": "Renounce ownership of the Stash factory", "fields": [] },
+      "requestOwnershipHandover()": {
+        "intent": "Request Ownership Handover",
+        "interpolatedIntent": "Request a handover of the Stash factory ownership",
+        "fields": []
+      },
       "completeOwnershipHandover(address pendingOwner)": {
         "intent": "Complete Ownership Handover",
+        "interpolatedIntent": "Hand over factory ownership to {#.pendingOwner}",
         "fields": [{ "path": "#.pendingOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
       },
-      "cancelOwnershipHandover()": { "intent": "Cancel Ownership Handover", "fields": [] },
+      "cancelOwnershipHandover()": {
+        "intent": "Cancel Ownership Handover",
+        "interpolatedIntent": "Cancel your pending factory ownership handover",
+        "fields": []
+      },
       "grantRoles(address user, uint256 roles)": {
         "intent": "Grant Roles",
+        "interpolatedIntent": "Grant roles {#.roles} to {#.user}",
         "fields": [
           { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
           { "path": "#.roles", "label": "Roles", "format": "raw" }
@@ -52,12 +65,17 @@
       },
       "revokeRoles(address user, uint256 roles)": {
         "intent": "Revoke Roles",
+        "interpolatedIntent": "Revoke roles {#.roles} from {#.user}",
         "fields": [
           { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
           { "path": "#.roles", "label": "Roles", "format": "raw" }
         ]
       },
-      "renounceRoles(uint256 roles)": { "intent": "Renounce Roles", "fields": [{ "path": "#.roles", "label": "Roles", "format": "raw" }] }
+      "renounceRoles(uint256 roles)": {
+        "intent": "Renounce Roles",
+        "interpolatedIntent": "Renounce roles {#.roles}",
+        "fields": [{ "path": "#.roles", "label": "Roles", "format": "raw" }]
+      }
     }
   }
 }

--- a/registry/cryptopunks/calldata-StashFactory.json
+++ b/registry/cryptopunks/calldata-StashFactory.json
@@ -10,34 +10,56 @@
     "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:35Z" }
   },
   "display": {
-    "definitions": {
-      "account": { "format": "addressName", "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] } },
-      "contractAddress": { "format": "addressName", "params": { "types": ["contract"], "sources": ["local", "ens"] } }
-    },
     "formats": {
       "deployStash(address _owner)": {
         "intent": "Create Stash",
         "interpolatedIntent": "Create Stash for {#._owner}",
-        "fields": [{ "path": "#._owner", "label": "Stash Owner", "$ref": "$.display.definitions.account" }]
+        "fields": [
+          {
+            "path": "#._owner",
+            "label": "Stash Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
+        ]
       },
       "upgradeStash()": { "intent": "Upgrade Stash", "interpolatedIntent": "Upgrade your Stash to the latest version", "fields": [] },
       "setAuction(address auction, bool _isAuction)": {
         "intent": "Set Marketplace Status",
         "interpolatedIntent": "Set marketplace {#.auction} enabled: {#._isAuction}",
         "fields": [
-          { "path": "#.auction", "label": "Marketplace", "$ref": "$.display.definitions.contractAddress" },
+          {
+            "path": "#.auction",
+            "label": "Marketplace",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#._isAuction", "label": "Enabled", "format": "raw" }
         ]
       },
       "addVersion(address implementation)": {
         "intent": "Add Stash Implementation",
         "interpolatedIntent": "Add Stash implementation {#.implementation}",
-        "fields": [{ "path": "#.implementation", "label": "Implementation", "$ref": "$.display.definitions.contractAddress" }]
+        "fields": [
+          {
+            "path": "#.implementation",
+            "label": "Implementation",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local", "ens"] }
+          }
+        ]
       },
       "transferOwnership(address newOwner)": {
         "intent": "Transfer Factory Ownership",
         "interpolatedIntent": "Transfer factory ownership to {#.newOwner}",
-        "fields": [{ "path": "#.newOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
+        "fields": [
+          {
+            "path": "#.newOwner",
+            "label": "New Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
+        ]
       },
       "renounceOwnership()": { "intent": "Renounce Factory Ownership", "interpolatedIntent": "Renounce ownership of the Stash factory", "fields": [] },
       "requestOwnershipHandover()": {
@@ -48,7 +70,14 @@
       "completeOwnershipHandover(address pendingOwner)": {
         "intent": "Complete Ownership Handover",
         "interpolatedIntent": "Hand over factory ownership to {#.pendingOwner}",
-        "fields": [{ "path": "#.pendingOwner", "label": "New Owner", "$ref": "$.display.definitions.account" }]
+        "fields": [
+          {
+            "path": "#.pendingOwner",
+            "label": "New Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          }
+        ]
       },
       "cancelOwnershipHandover()": {
         "intent": "Cancel Ownership Handover",
@@ -59,7 +88,12 @@
         "intent": "Grant Roles",
         "interpolatedIntent": "Grant roles {#.roles} to {#.user}",
         "fields": [
-          { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
+          {
+            "path": "#.user",
+            "label": "Account",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.roles", "label": "Roles", "format": "raw" }
         ]
       },
@@ -67,7 +101,12 @@
         "intent": "Revoke Roles",
         "interpolatedIntent": "Revoke roles {#.roles} from {#.user}",
         "fields": [
-          { "path": "#.user", "label": "Account", "$ref": "$.display.definitions.account" },
+          {
+            "path": "#.user",
+            "label": "Account",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] }
+          },
           { "path": "#.roles", "label": "Roles", "format": "raw" }
         ]
       },

--- a/registry/cryptopunks/eip712-PunkBid.json
+++ b/registry/cryptopunks/eip712-PunkBid.json
@@ -21,13 +21,8 @@
             "format": "addressName",
             "params": { "types": ["contract"], "sources": ["local", "ens"] }
           },
-          { "path": "order.numberOfUnits", "label": "Quantity", "format": "raw", "visible": { "ifNotIn": [1] } },
-          {
-            "path": "root",
-            "label": "Punk Set Root",
-            "format": "raw",
-            "visible": { "ifNotIn": ["0x0000000000000000000000000000000000000000000000000000000000000000"] }
-          },
+          { "path": "order.numberOfUnits", "label": "Quantity", "format": "raw" },
+          { "path": "root", "label": "Punk Set Root", "format": "raw" },
           { "path": "accountNonce", "label": "Account Nonce", "format": "raw", "visible": "never" },
           { "path": "bidNonce", "label": "Bid ID", "format": "raw", "visible": "never" }
         ]

--- a/registry/cryptopunks/eip712-PunkBid.json
+++ b/registry/cryptopunks/eip712-PunkBid.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": { "$id": "PunkBid", "eip712": { "deployments": [{ "chainId": 1, "address": "0x00000000000060D035a8002956B5fb02e3968eec" }] } },
+  "metadata": {
+    "owner": "CryptoPunks",
+    "contractName": "Stash",
+    "info": { "url": "https://cryptopunks.app", "deploymentDate": "2024-01-17T22:48:47Z" }
+  },
+  "display": {
+    "formats": {
+      "PunkBid(Order order,uint256 accountNonce,uint256 bidNonce,uint256 expiration,bytes32 root)Order(uint16 numberOfUnits,uint80 pricePerUnit,address auction)": {
+        "$id": "PunkBid",
+        "intent": "Place Punk Bid",
+        "interpolatedIntent": "Punk Bid: {order.pricePerUnit}",
+        "fields": [
+          { "path": "order.pricePerUnit", "label": "Bid Amount", "format": "amount" },
+          { "path": "expiration", "label": "Expires", "format": "date", "params": { "encoding": "timestamp" } },
+          {
+            "path": "order.auction",
+            "label": "Marketplace",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local", "ens"] }
+          },
+          { "path": "order.numberOfUnits", "label": "Quantity", "format": "raw", "visible": { "ifNotIn": [1] } },
+          {
+            "path": "root",
+            "label": "Punk Set Root",
+            "format": "raw",
+            "visible": { "ifNotIn": ["0x0000000000000000000000000000000000000000000000000000000000000000"] }
+          },
+          { "path": "accountNonce", "label": "Account Nonce", "format": "raw", "visible": "never" },
+          { "path": "bidNonce", "label": "Bid ID", "format": "raw", "visible": "never" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/cryptopunks/testsv2/calldata-CryptoPunks721.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-CryptoPunks721.tests.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-CryptoPunks721.json",
+  "tests": [
+    {
+      "description": "Wrap Punk - chain 1",
+      "rawTx": "0x02f84c01318477359400847bd969fc8304fe0694000000000000003607fce1ac9e043a86675c5c2f80a490aaf2ff0000000000000000000000000000000000000000000000000000000000000ff8c0",
+      "txHash": "0x1bf5d867f0884689ef4ee76d387624d029ccbcfdfba66e3f095ae4a2bc8ee972",
+      "expected": {
+        "intent": "Wrap Punk",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "4088" }],
+        "interpolatedIntent": "Wrap Punk #4088"
+      }
+    },
+    {
+      "description": "Unwrap Punk - chain 1",
+      "rawTx": "0x02f84e01821d138429b927008429b927008301ec4294000000000000003607fce1ac9e043a86675c5c2f80a49f8f573f00000000000000000000000000000000000000000000000000000000000015cdc0",
+      "txHash": "0x0ff7f10b7999c6719583482b42bf2b3337eae169e5aeeb8cf4abf181d1708511",
+      "expected": {
+        "intent": "Unwrap Punk",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "5581" }],
+        "interpolatedIntent": "Unwrap Punk #5581"
+      }
+    },
+    {
+      "description": "Safe Transfer Wrapped Punk - chain 1",
+      "rawTx": "0x02f88d01148423c34600842affb0c083016a4c94000000000000003607fce1ac9e043a86675c5c2f80b86442842e0e0000000000000000000000000e4dc24547fa37d27e530e21f58de86a00955b3800000000000000000000000037d992ce46e6ae90fff0451f3d46f5079476ea4200000000000000000000000000000000000000000000000000000000000020b6c0",
+      "txHash": "0x439d60b420a7fe91043dadd1ac39182852acdf6f1aba8bfa36f2c542e362d48a",
+      "expected": {
+        "intent": "Transfer Wrapped Punk",
+        "owner": "CryptoPunks",
+        "fields": [
+          { "label": "Punk", "value": "8374" },
+          { "label": "From", "value": "0x0E4DC24547fA37D27e530E21F58DE86A00955b38" },
+          { "label": "Recipient", "value": "0x37D992Ce46E6aE90FFF0451F3d46f5079476Ea42" }
+        ],
+        "interpolatedIntent": "Transfer Punk #8374"
+      }
+    },
+    {
+      "description": "Wrap Punks batch (synthetic) - chain 1",
+      "rawTx": "0x02f8ce0107843b9aca008506fc23ac0083030d4094000000000000003607fce1ac9e043a86675c5c2f80b8a49e88cf4200000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003c0",
+      "expected": {
+        "intent": "Wrap Punks",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "1" }, { "label": "Punk", "value": "2" }, { "label": "Punk", "value": "3" }]
+      }
+    }
+  ]
+}

--- a/registry/cryptopunks/testsv2/calldata-CryptoPunks721.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-CryptoPunks721.tests.json
@@ -45,7 +45,8 @@
       "expected": {
         "intent": "Wrap Punks",
         "owner": "CryptoPunks",
-        "fields": [{ "label": "Punk", "value": "1" }, { "label": "Punk", "value": "2" }, { "label": "Punk", "value": "3" }]
+        "fields": [{ "label": "Punk", "value": "1" }, { "label": "Punk", "value": "2" }, { "label": "Punk", "value": "3" }],
+        "interpolatedIntent": "Wrap the selected Punks as ERC-721s"
       }
     }
   ]

--- a/registry/cryptopunks/testsv2/calldata-CryptoPunksMarket.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-CryptoPunksMarket.tests.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-CryptoPunksMarket.json",
+  "tests": [
+    {
+      "description": "Buy Punk - chain 1",
+      "rawTx": "0x02f85501448408f0d18084181b34e58301a5f294b47e3cd837ddf8e4c57f05d70ab865de6e193bbb89019ef22395402e0000a48264fe980000000000000000000000000000000000000000000000000000000000002102c0",
+      "txHash": "0x868084357227900eae9f2e9ff4d707a9be1203506ec35071560b962316277ba0",
+      "expected": {
+        "intent": "Buy Punk",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "8450" }, { "label": "Price", "value": "29.9 ETH" }],
+        "interpolatedIntent": "Buy Punk #8450"
+      }
+    },
+    {
+      "description": "Bid on Punk (legacy tx) - chain 1",
+      "rawTx": "0xf8538209d08406f7f39f83030d4094b47e3cd837ddf8e4c57f05d70ab865de6e193bbb890178168a6b05160000a4091dbfd200000000000000000000000000000000000000000000000000000000000016ea018080",
+      "txHash": "0x721aaf2f2b71adf6e728fcf34d8dfa74c8c0868f70ea8c7c1b1705b2214ac178",
+      "expected": {
+        "intent": "Bid on Punk",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "5866" }, { "label": "Bid Amount", "value": "27.1 ETH" }],
+        "interpolatedIntent": "Bid on Punk #5866"
+      }
+    },
+    {
+      "description": "Withdraw Bid - chain 1",
+      "rawTx": "0x02f84c01268477359400847c91a693830145d894b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80a4979bc6380000000000000000000000000000000000000000000000000000000000000bb4c0",
+      "txHash": "0x910f96db8074f5738b1a4b8e2bc41eff65f895ce765126d2a3c98220bc250a5e",
+      "expected": {
+        "intent": "Withdraw Bid",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "2996" }],
+        "interpolatedIntent": "Withdraw Bid on #2996"
+      }
+    },
+    {
+      "description": "Accept Bid (synthetic) - chain 1",
+      "rawTx": "0x02f86e0107843b9aca008506fc23ac0083030d4094b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80b84423165b750000000000000000000000000000000000000000000000000000000000001e320000000000000000000000000000000000000000000000015af1d78b58c40000c0",
+      "expected": {
+        "intent": "Accept Bid",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "7730" }, { "label": "Minimum Price", "value": "25 ETH" }],
+        "interpolatedIntent": "Accept Bid on #7730"
+      }
+    },
+    {
+      "description": "List Punk for Sale - chain 1",
+      "rawTx": "0x02f86e0182015c8477359400847c36880782fc1394b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80b844c44193c30000000000000000000000000000000000000000000000000000000000000fdb000000000000000000000000000000000000000000000001ba01ee4060310000c0",
+      "txHash": "0x1cc50a99d78677cbac4c9204757d337da555cdae573f0e96bd2065fecccf8723",
+      "expected": {
+        "intent": "List Punk for Sale",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "4059" }, { "label": "Price", "value": "31.85 ETH" }],
+        "interpolatedIntent": "List Punk #4059"
+      }
+    },
+    {
+      "description": "List Punk for Private Sale (synthetic) - chain 1",
+      "rawTx": "0x02f88e0107843b9aca008506fc23ac0083030d4094b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80b864bf31196f0000000000000000000000000000000000000000000000000000000000001e32000000000000000000000000000000000000000000000001a055690d9db80000000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44ec0",
+      "expected": {
+        "intent": "List Punk for Private Sale",
+        "owner": "CryptoPunks",
+        "fields": [
+          { "label": "Punk", "value": "7730" },
+          { "label": "Price", "value": "30 ETH" },
+          { "label": "Buyer", "value": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e" }
+        ],
+        "interpolatedIntent": "Offer Punk #7730"
+      }
+    },
+    {
+      "description": "Remove Punk Listing - chain 1",
+      "rawTx": "0x02f84c01458423c34600842e6b8b8083010c3b94b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80a4f6eeff1e00000000000000000000000000000000000000000000000000000000000012c6c0",
+      "txHash": "0xac0fd14ed658acb4f76e553f02db0517e80cb1da8aab455e464f2fea293d6f53",
+      "expected": {
+        "intent": "Remove Punk Listing",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "4806" }],
+        "interpolatedIntent": "Delist Punk #4806"
+      }
+    },
+    {
+      "description": "Transfer Punk - chain 1",
+      "rawTx": "0x02f86f01821d118429b927008429b927008301e29594b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80b8448b72a2ec000000000000000000000000b702efdb1c426b757826d784f4584e8c8054b8c700000000000000000000000000000000000000000000000000000000000015cdc0",
+      "txHash": "0x60e32810709cb1fccb1bcf678531c54413dcca6a0a86e50eee54518f7b04c8d5",
+      "expected": {
+        "intent": "Transfer Punk",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Punk", "value": "5581" }, { "label": "Recipient", "value": "0xB702eFDB1c426B757826D784F4584e8C8054B8c7" }],
+        "interpolatedIntent": "Transfer Punk #5581"
+      }
+    },
+    {
+      "description": "Withdraw ETH Balance (synthetic) - chain 1",
+      "rawTx": "0x02ed0107843b9aca008506fc23ac0083030d4094b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80843ccfd60bc0",
+      "expected": { "intent": "Withdraw ETH Balance", "owner": "CryptoPunks", "fields": [] }
+    }
+  ]
+}

--- a/registry/cryptopunks/testsv2/calldata-CryptoPunksMarket.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-CryptoPunksMarket.tests.json
@@ -95,7 +95,12 @@
     {
       "description": "Withdraw ETH Balance (synthetic) - chain 1",
       "rawTx": "0x02ed0107843b9aca008506fc23ac0083030d4094b47e3cd837ddf8e4c57f05d70ab865de6e193bbb80843ccfd60bc0",
-      "expected": { "intent": "Withdraw ETH Balance", "owner": "CryptoPunks", "fields": [] }
+      "expected": {
+        "intent": "Withdraw ETH Balance",
+        "owner": "CryptoPunks",
+        "fields": [],
+        "interpolatedIntent": "Withdraw your ETH balance from the CryptoPunks market"
+      }
     }
   ]
 }

--- a/registry/cryptopunks/testsv2/calldata-Stash.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-Stash.tests.json
@@ -18,7 +18,8 @@
           { "label": "Punk", "value": "3797" },
           { "label": "Sale Price", "value": "30.5 ETH" },
           { "label": "Bid Expiration", "value": "2026-09-06 20:44:21Z" },
-          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" }
+          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          { "label": "Quantity", "value": "1" }
         ],
         "interpolatedIntent": "Sell Punk #3797"
       }

--- a/registry/cryptopunks/testsv2/calldata-Stash.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-Stash.tests.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-Stash.json",
+  "dataProvider": {
+    "tokens": {
+      "0x0000000000000000000000000000000000000000": { "symbol": "ETH", "decimals": 18, "name": "Ether" },
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": { "symbol": "WETH", "decimals": 18, "name": "Wrapped Ether" }
+    }
+  },
+  "tests": [
+    {
+      "description": "Accept Punk Bid (calldata from 0x7377b353) - chain 1",
+      "rawTx": "0x02f90211018201d58477359400847f9a27e484010000009400000000000060d035a8002956b5fb02e3968eec80b901e4e4d84d760000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000001a745c467716a0000000000000000000000000000b47e3cd837ddf8e4c57f05d70ab865de6e193bbb0000000000000000000000000000000000000000000000000000000000000035000000000000000000000000000000000000000000000000000001a06903f0ea000000000000000000000000000000000000000000000000000000006a9dd0a5f05f250ff27e143e3a85f413a12177f65e92cbe53204a6aed1a14ae9830c15660000000000000000000000000000000000000000000000000000000000000ed5000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001c000000000000000000000000000000000000000000000000000000000000000410e1909cfa9aaaa1d6b93b7e7cfd0664b95d40498c14675ebce7bc3f4b7b41d7f6b00bcb6577cb44b61d560261d01da2ae61b36e7fac14178efb235fb76aadeec1c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0",
+      "expected": {
+        "intent": "Accept Punk Bid",
+        "owner": "CryptoPunks",
+        "fields": [
+          { "label": "Punk", "value": "3797" },
+          { "label": "Sale Price", "value": "30.5 ETH" },
+          { "label": "Bid Expiration", "value": "2026-09-06 20:44:21Z" },
+          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" }
+        ],
+        "interpolatedIntent": "Sell Punk #3797"
+      }
+    },
+    {
+      "description": "Cancel Punk Bid (calldata from 0xe7fc5e7f) - chain 1",
+      "rawTx": "0x02f84d018202ed8405f5e100840d60b8a482f4fa9400000000000060d035a8002956b5fb02e3968eec80a44cce45e7000000000000000000000000000000000000000000000000000001a082ca5944c0",
+      "expected": { "intent": "Cancel Punk Bid", "owner": "CryptoPunks", "fields": [{ "label": "Bid ID", "value": "1788900694340" }] }
+    },
+    {
+      "description": "Cancel All Punk Bids (calldata from 0x488b5a91) - chain 1",
+      "rawTx": "0x02ed018202b28405f5e100840ad6d9828297b69400000000000060d035a8002956b5fb02e3968eec8084b68463b9c0",
+      "expected": { "intent": "Cancel All Punk Bids", "owner": "CryptoPunks", "fields": [] }
+    },
+    {
+      "description": "Withdraw ETH from Stash (synthetic) - chain 1",
+      "rawTx": "0x02f86e0107843b9aca008506fc23ac0083030d409400000000000060d035a8002956b5fb02e3968eec80b844f3fef3a3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014d1120d7b160000c0",
+      "expected": {
+        "intent": "Withdraw from Stash",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Amount", "value": "1.5 ETH" }],
+        "interpolatedIntent": "Withdraw 1.5 ETH"
+      }
+    },
+    {
+      "description": "Withdraw WETH from Stash (synthetic) - chain 1",
+      "rawTx": "0x02f86e0107843b9aca008506fc23ac0083030d409400000000000060d035a8002956b5fb02e3968eec80b844f3fef3a3000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000001bc16d674ec80000c0",
+      "expected": {
+        "intent": "Withdraw from Stash",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Amount", "value": "2 WETH" }],
+        "interpolatedIntent": "Withdraw 2 WETH"
+      }
+    }
+  ]
+}

--- a/registry/cryptopunks/testsv2/calldata-Stash.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-Stash.tests.json
@@ -26,12 +26,22 @@
     {
       "description": "Cancel Punk Bid (calldata from 0xe7fc5e7f) - chain 1",
       "rawTx": "0x02f84d018202ed8405f5e100840d60b8a482f4fa9400000000000060d035a8002956b5fb02e3968eec80a44cce45e7000000000000000000000000000000000000000000000000000001a082ca5944c0",
-      "expected": { "intent": "Cancel Punk Bid", "owner": "CryptoPunks", "fields": [{ "label": "Bid ID", "value": "1788900694340" }] }
+      "expected": {
+        "intent": "Cancel Punk Bid",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Bid ID", "value": "1788900694340" }],
+        "interpolatedIntent": "Cancel Punk bid 1788900694340"
+      }
     },
     {
       "description": "Cancel All Punk Bids (calldata from 0x488b5a91) - chain 1",
       "rawTx": "0x02ed018202b28405f5e100840ad6d9828297b69400000000000060d035a8002956b5fb02e3968eec8084b68463b9c0",
-      "expected": { "intent": "Cancel All Punk Bids", "owner": "CryptoPunks", "fields": [] }
+      "expected": {
+        "intent": "Cancel All Punk Bids",
+        "owner": "CryptoPunks",
+        "fields": [],
+        "interpolatedIntent": "Cancel every open Punk bid from your Stash"
+      }
     },
     {
       "description": "Withdraw ETH from Stash (synthetic) - chain 1",

--- a/registry/cryptopunks/testsv2/calldata-StashFactory.tests.json
+++ b/registry/cryptopunks/testsv2/calldata-StashFactory.tests.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-StashFactory.json",
+  "tests": [
+    {
+      "description": "Create Stash - chain 1",
+      "rawTx": "0x02f84e018202048477359400847b63f4bc8303231f94000000000000a6fa31f5fc51c1640aac7686675080a41d8564190000000000000000000000006a42a2b53f320421846a98e0531f01b917d329efc0",
+      "txHash": "0x5d69e11a15306d845daa68a5cef54637382987e24525e9a42b71f4bef925701e",
+      "expected": {
+        "intent": "Create Stash",
+        "owner": "CryptoPunks",
+        "fields": [{ "label": "Stash Owner", "value": "0x6A42a2B53f320421846a98e0531f01B917D329eF" }],
+        "interpolatedIntent": "Create Stash for 0x6A42a2B53f320421846a98e0531f01B917D329eF"
+      }
+    }
+  ]
+}

--- a/registry/cryptopunks/testsv2/eip712-PunkBid.tests.json
+++ b/registry/cryptopunks/testsv2/eip712-PunkBid.tests.json
@@ -38,12 +38,13 @@
           { "label": "Bid Amount", "value": "30.5 ETH" },
           { "label": "Expires", "value": "2026-09-06 20:44:21Z" },
           { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          { "label": "Quantity", "value": "1" },
           { "label": "Punk Set Root", "value": "0xf05f250ff27e143e3a85f413a12177f65e92cbe53204a6aed1a14ae9830c1566" }
         ]
       }
     },
     {
-      "description": "Collection-wide bid (zero root hidden) - chain 1",
+      "description": "Collection-wide bid (zero root) - chain 1",
       "data": {
         "types": {
           "EIP712Domain": [{ "name": "chainId", "type": "uint256" }, { "name": "verifyingContract", "type": "address" }],
@@ -77,7 +78,9 @@
         "fields": [
           { "label": "Bid Amount", "value": "30.5 ETH" },
           { "label": "Expires", "value": "2026-09-06 20:44:21Z" },
-          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" }
+          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          { "label": "Quantity", "value": "1" },
+          { "label": "Punk Set Root", "value": "0x0000000000000000000000000000000000000000000000000000000000000000" }
         ]
       }
     }

--- a/registry/cryptopunks/testsv2/eip712-PunkBid.tests.json
+++ b/registry/cryptopunks/testsv2/eip712-PunkBid.tests.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../eip712-PunkBid.json",
+  "tests": [
+    {
+      "description": "Bid on a specific set of Punks - chain 1",
+      "data": {
+        "types": {
+          "EIP712Domain": [{ "name": "chainId", "type": "uint256" }, { "name": "verifyingContract", "type": "address" }],
+          "PunkBid": [
+            { "name": "order", "type": "Order" },
+            { "name": "accountNonce", "type": "uint256" },
+            { "name": "bidNonce", "type": "uint256" },
+            { "name": "expiration", "type": "uint256" },
+            { "name": "root", "type": "bytes32" }
+          ],
+          "Order": [
+            { "name": "numberOfUnits", "type": "uint16" },
+            { "name": "pricePerUnit", "type": "uint80" },
+            { "name": "auction", "type": "address" }
+          ]
+        },
+        "primaryType": "PunkBid",
+        "domain": { "chainId": 1, "verifyingContract": "0x00000000000060D035a8002956B5fb02e3968eec" },
+        "message": {
+          "order": { "numberOfUnits": 1, "pricePerUnit": "30500000000000000000", "auction": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          "accountNonce": "53",
+          "bidNonce": "1788468261098",
+          "expiration": "1788727461",
+          "root": "0xf05f250ff27e143e3a85f413a12177f65e92cbe53204a6aed1a14ae9830c1566"
+        }
+      },
+      "expected": {
+        "intent": "Place Punk Bid",
+        "interpolatedIntent": "Punk Bid: 30.5 ETH",
+        "owner": "CryptoPunks",
+        "fields": [
+          { "label": "Bid Amount", "value": "30.5 ETH" },
+          { "label": "Expires", "value": "2026-09-06 20:44:21Z" },
+          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          { "label": "Punk Set Root", "value": "0xf05f250ff27e143e3a85f413a12177f65e92cbe53204a6aed1a14ae9830c1566" }
+        ]
+      }
+    },
+    {
+      "description": "Collection-wide bid (zero root hidden) - chain 1",
+      "data": {
+        "types": {
+          "EIP712Domain": [{ "name": "chainId", "type": "uint256" }, { "name": "verifyingContract", "type": "address" }],
+          "PunkBid": [
+            { "name": "order", "type": "Order" },
+            { "name": "accountNonce", "type": "uint256" },
+            { "name": "bidNonce", "type": "uint256" },
+            { "name": "expiration", "type": "uint256" },
+            { "name": "root", "type": "bytes32" }
+          ],
+          "Order": [
+            { "name": "numberOfUnits", "type": "uint16" },
+            { "name": "pricePerUnit", "type": "uint80" },
+            { "name": "auction", "type": "address" }
+          ]
+        },
+        "primaryType": "PunkBid",
+        "domain": { "chainId": 1, "verifyingContract": "0x00000000000060D035a8002956B5fb02e3968eec" },
+        "message": {
+          "order": { "numberOfUnits": 1, "pricePerUnit": "30500000000000000000", "auction": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" },
+          "accountNonce": "53",
+          "bidNonce": "1788468261099",
+          "expiration": "1788727461",
+          "root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      "expected": {
+        "intent": "Place Punk Bid",
+        "interpolatedIntent": "Punk Bid: 30.5 ETH",
+        "owner": "CryptoPunks",
+        "fields": [
+          { "label": "Bid Amount", "value": "30.5 ETH" },
+          { "label": "Expires", "value": "2026-09-06 20:44:21Z" },
+          { "label": "Marketplace", "value": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Add CryptoPunks descriptors

Adds `registry/cryptopunks/` with ERC-7730 v2 descriptors for the contracts behind
[cryptopunks.app](https://cryptopunks.app), the official CryptoPunks marketplace, plus
the EIP-712 message users sign when placing a bid. Ethereum mainnet only.

## Descriptors

| File | Contract | Address |
|---|---|---|
| `calldata-CryptoPunksMarket.json` | Original 2017 CryptoPunks market (buy, bid, accept bid, list, private sale, delist, transfer, withdraw) | `0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB` |
| `calldata-CryptoPunks721.json` | ERC-721 wrapper for punks (wrap, unwrap, batch variants, legacy migration, approvals, transfers) | `0x000000000000003607fce1aC9e043a86675C5C2F` |
| `calldata-StashFactory.json` | Deploys and upgrades per-user bidding Stashes | `0x000000000000A6fA31F5fC51c1640aAc76866750` |
| `calldata-Stash.json` | Per-user Stash: accept a bid (`processPunkBid`), cancel bids, withdraw ETH/WETH/NFTs, orders | implementation `0x00000000000060D035a8002956B5fb02e3968eec` |
| `eip712-PunkBid.json` | `PunkBid` typed message signed off-chain when placing a bid | same implementation address |

All four contracts are exact-match verified on Sourcify.

## Notes for reviewers

**Stash binding.** Every user has their own Stash, deployed by `StashFactory` as an
ERC-1967 minimal proxy, and the `PunkBid` EIP-712 domain uses that per-user address as
`verifyingContract` (the domain has only `chainId` and `verifyingContract`, no name or
version). Following the spec's "Multi-instanciation" guidance, both Stash descriptors
bind to the implementation address, and `calldata-Stash.json` additionally carries a
`factory` constraint (`Deployed(address,address)` emitted by the factory). This is the
first `factory` usage in the registry, so feedback on the event-signature form is welcome.

**Hidden fields.** Signatures, merkle proofs, nonces and the bid merkle root (when it is
the zero root, meaning a collection-wide bid) are hidden. Prices use `amount`, expirations
use `date`, addresses use `addressName` with ENS. The Stash `withdraw` uses `tokenAmount`
with `nativeCurrencyAddress` set to the zero address, matching how the dapp passes ETH.

**Omitted functions.** The market's one-time 2017 setup functions
(`setInitialOwner(s)`, `allInitialOwnersAssigned`) and the Stash's `onERC721Received` /
`onERC1155*Received` hooks have no display format on purpose. The 0.4.x market ABI marks
view functions with `constant` instead of `stateMutability`, so the linter also warns
about those; there are no errors.

## Tests

`testsv2/` has one fixture file per descriptor, 21 cases total. 15 are built from real
mainnet transactions and carry their `txHash`; 6 are synthetic and labelled as such
(functions with no recent on-chain calls). Stash fixtures use the implementation address
as `to` / `verifyingContract`, as the Safe fixtures do, since offline runners cannot
resolve a proxy; the calldata is unchanged and the source hash is in each description.

## Checklist

- [x] `erc7730 lint` on all five descriptors: 0 errors
- [x] `erc7730 format`: clean
- [x] Fixtures validate against `erc7730-tests-v2.schema.json`
- [x] Only `registry/cryptopunks/` touched
