### PR TITLE
ci: check that every function of a calldata descriptor has a test

### DIFF
--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -141,12 +141,19 @@ function checkDescriptor(descriptorAbs) {
 
   const covered = new Set();
   tests.forEach((test, i) => {
+    const name = test?.description ? JSON.stringify(test.description) : `#${i + 1}`;
+    let selector;
     try {
-      covered.add(testSelector(test));
+      selector = testSelector(test);
     } catch (error) {
-      const name = test?.description ? JSON.stringify(test.description) : `#${i + 1}`;
       errors.push(`Test ${name} in ${testFile} has a rawTx that cannot be decoded: ${reason(error)}`);
+      return;
     }
+    if (!selectors.has(selector)) {
+      errors.push(`Test ${name} in ${testFile} calls ${selector}, which no format of the descriptor matches`);
+      return;
+    }
+    covered.add(selector);
   });
 
   const uncovered = [...selectors].filter(([selector]) => !covered.has(selector));

--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -11,9 +11,10 @@
  * selector no test calls is an error. EIP-712 descriptors have no selector
  * and are skipped.
  *
- * Usage: node check-selector-coverage.js <descriptor.json|directory>...
+ * Usage: node check-selector-coverage.js [--report <file>] <descriptor.json|directory>...
  *   A directory is walked for calldata-*.json descriptors, skipping the
- *   tests/, testsv2/ and sigs/ folders.
+ *   tests/, testsv2/ and sigs/ folders. With --report, the errors are also
+ *   written to <file> as JSON, keyed by descriptor, for the results comment.
  *
  * Prints GitHub Actions annotations, and exits 1 when a function has no test,
  * a format key is not a function signature, or a test cannot be decoded.
@@ -21,6 +22,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { parseArgs } = require('util');
 const { parseAbiItem, parseTransaction, slice, toFunctionSelector } = require('viem');
 const { resolveDescriptor } = require('./resolve-erc7730-includes');
 
@@ -76,11 +78,7 @@ function testSelector(test) {
 
 // --- Check -------------------------------------------------------------------
 
-/**
- * The errors of one descriptor, or null when there is nothing to check: the
- * descriptor formats no function, or it has no test file (the require-testsv2
- * job reports it).
- */
+/** The errors of one descriptor, or null when it formats no function. */
 function checkDescriptor(descriptorAbs) {
   const descriptor = rel(descriptorAbs);
   const errors = [];
@@ -111,12 +109,7 @@ function checkDescriptor(descriptorAbs) {
   try {
     fixture = JSON.parse(fs.readFileSync(path.join(repoRoot, testFile), 'utf8'));
   } catch (error) {
-    if (error.code === 'ENOENT') {
-      // require-testsv2 reports the missing file; it is a different fix.
-      process.stderr.write(`warning: ${descriptor} has no test file ${testFile}\n`);
-      return errors.length > 0 ? errors : null;
-    }
-    errors.push(`Cannot read ${testFile}: ${error.message}`);
+    errors.push(`Cannot read ${testFile}: ${error.code === 'ENOENT' ? 'no such file' : error.message}`);
     return errors;
   }
 
@@ -167,15 +160,19 @@ function checkDescriptor(descriptorAbs) {
 }
 
 function main() {
-  const targets = process.argv.slice(2);
+  const { values, positionals: targets } = parseArgs({
+    options: { report: { type: 'string' } },
+    allowPositionals: true,
+  });
   if (targets.length === 0) {
-    process.stderr.write('Usage: node check-selector-coverage.js <descriptor.json|directory>...\n');
+    process.stderr.write('Usage: node check-selector-coverage.js [--report <file>] <descriptor.json|directory>...\n');
     process.exit(2);
   }
 
   const descriptors = [...new Set(targets.flatMap((t) => collectDescriptors(path.resolve(t), [])))].sort();
   let checked = 0;
   let failed = 0;
+  const report = {};
   for (const descriptorAbs of descriptors) {
     const descriptor = rel(descriptorAbs);
     if (!/^calldata-/.test(path.basename(descriptor))) continue;
@@ -190,7 +187,12 @@ function main() {
       continue;
     }
     failed++;
+    report[descriptor] = result;
     for (const message of result) console.log(`::error file=${descriptor},line=1::${message}`);
+  }
+  if (values.report) {
+    fs.mkdirSync(path.dirname(values.report), { recursive: true });
+    fs.writeFileSync(values.report, JSON.stringify(report, null, 2));
   }
 
   const summary = `${failed} of ${checked} descriptor(s) failed the check.`;

--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -78,8 +78,8 @@ function testSelector(test) {
 
 /**
  * The errors of one descriptor, or null when there is nothing to check: the
- * descriptor cannot be read (another job reports it), it formats no function,
- * or it has no test file (the require-testsv2 job reports it).
+ * descriptor formats no function, or it has no test file (the require-testsv2
+ * job reports it).
  */
 function checkDescriptor(descriptorAbs) {
   const descriptor = rel(descriptorAbs);
@@ -89,9 +89,7 @@ function checkDescriptor(descriptorAbs) {
   try {
     formats = resolveDescriptor(descriptorAbs).display?.formats ?? {};
   } catch (error) {
-    // Another job reports the malformed descriptor; there is nothing to cover.
-    process.stderr.write(`warning: cannot read ${descriptor}: ${error.message}\n`);
-    return null;
+    return [`Cannot read the descriptor: ${error.message}`];
   }
 
   const selectors = new Map(); // selector -> the keys that hash to it
@@ -173,7 +171,7 @@ function main() {
     for (const message of result) console.log(`::error file=${descriptor},line=1::${message}`);
   }
 
-  const summary = `${failed} of ${checked} descriptor(s) have a function without a test.`;
+  const summary = `${failed} of ${checked} descriptor(s) failed the check.`;
   console.log(summary);
   if (process.env.GITHUB_STEP_SUMMARY && failed > 0) {
     // GitHub shows 10 annotations per step, so give the total as well.

--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -65,9 +65,10 @@ function selectorOf(key) {
   return toFunctionSelector(parseAbiItem(`function ${key.trim()}`));
 }
 
-/** The selector called by a test case, or null when the test is not a calldata test. */
+/** The selector called by a test case. */
 function testSelector(test) {
-  if (typeof test.rawTx !== 'string') return null;
+  // The schema allows an EIP-712 test in a calldata fixture; it covers nothing.
+  if (typeof test.rawTx !== 'string') throw new Error('test has no rawTx');
   const data = parseTransaction(test.rawTx).data ?? '0x';
   if (data.length < 10) throw new Error('calldata shorter than 4 bytes');
   return slice(data, 0, 4);
@@ -128,8 +129,7 @@ function checkDescriptor(descriptorAbs) {
   const covered = new Set();
   tests.forEach((test, i) => {
     try {
-      const selector = testSelector(test);
-      if (selector) covered.add(selector);
+      covered.add(testSelector(test));
     } catch (error) {
       const name = test?.description ? JSON.stringify(test.description) : `#${i + 1}`;
       errors.push(`Test ${name} in ${testFile} has a rawTx that cannot be decoded: ${reason(error)}`);

--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -107,9 +107,9 @@ function checkDescriptor(descriptorAbs) {
   if (selectors.size === 0 && errors.length === 0) return null;
 
   const testFile = `${path.posix.dirname(descriptor)}/testsv2/${path.posix.basename(descriptor, '.json')}.tests.json`;
-  let tests;
+  let fixture;
   try {
-    tests = JSON.parse(fs.readFileSync(path.join(repoRoot, testFile), 'utf8')).tests;
+    fixture = JSON.parse(fs.readFileSync(path.join(repoRoot, testFile), 'utf8'));
   } catch (error) {
     if (error.code === 'ENOENT') {
       // require-testsv2 reports the missing file; it is a different fix.
@@ -119,6 +119,21 @@ function checkDescriptor(descriptorAbs) {
     errors.push(`Cannot read ${testFile}: ${error.message}`);
     return errors;
   }
+
+  // The file name pairs the fixture with the descriptor, and the "descriptor"
+  // field must agree. A fixture copied from another descriptor without
+  // updating the field would otherwise count the shared functions as covered.
+  const named = typeof fixture.descriptor === 'string'
+    ? path.resolve(repoRoot, path.dirname(testFile), fixture.descriptor)
+    : null;
+  if (named !== descriptorAbs) {
+    errors.push(
+      `${testFile} names ${JSON.stringify(fixture.descriptor ?? null)} as its descriptor, but its file name pairs it with ${descriptor}`,
+    );
+    return errors;
+  }
+
+  const tests = fixture.tests;
   if (!Array.isArray(tests)) {
     errors.push(`${testFile} has no "tests" array`);
     return errors;

--- a/.github/scripts/check-selector-coverage.js
+++ b/.github/scripts/check-selector-coverage.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Checks that every function a calldata descriptor formats has at least one
+ * test case in its testsv2 file.
+ *
+ * For each descriptor, the script resolves "includes", derives the 4-byte
+ * selector of every "display.formats" key, and reads the selector from the
+ * first 4 bytes of the calldata of every "rawTx" in
+ * registry/<entity>/testsv2/<descriptor-name>.tests.json. viem does the
+ * parsing on both sides. A format whose
+ * selector no test calls is an error. EIP-712 descriptors have no selector
+ * and are skipped.
+ *
+ * Usage: node check-selector-coverage.js <descriptor.json|directory>...
+ *   A directory is walked for calldata-*.json descriptors, skipping the
+ *   tests/, testsv2/ and sigs/ folders.
+ *
+ * Prints GitHub Actions annotations, and exits 1 when a function has no test,
+ * a format key is not a function signature, or a test cannot be decoded.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { parseAbiItem, parseTransaction, slice, toFunctionSelector } = require('viem');
+const { resolveDescriptor } = require('./resolve-erc7730-includes');
+
+const repoRoot = process.cwd();
+const EXCLUDED_DIRS = new Set(['tests', 'testsv2', 'sigs']);
+
+/** Repo-relative path with forward slashes. */
+function rel(absPath) {
+  return path.relative(repoRoot, absPath).split(path.sep).join('/');
+}
+
+function collectDescriptors(target, out) {
+  const stat = fs.statSync(target);
+  if (stat.isFile()) {
+    out.push(target);
+    return out;
+  }
+  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+    const full = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(entry.name)) collectDescriptors(full, out);
+    } else if (/^calldata-.*\.json$/.test(entry.name) && !entry.name.endsWith('.tests.json')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// --- Selectors ---------------------------------------------------------------
+
+/** viem errors carry a one-line summary; other errors only have a message. */
+function reason(error) {
+  return error.shortMessage ?? error.message;
+}
+
+/**
+ * The 4-byte selector of a "display.formats" key. The key is a function
+ * signature with parameter names, so the ABI parser strips the names and
+ * expands shorthands like "uint" before hashing.
+ */
+function selectorOf(key) {
+  return toFunctionSelector(parseAbiItem(`function ${key.trim()}`));
+}
+
+/** The selector called by a test case, or null when the test is not a calldata test. */
+function testSelector(test) {
+  if (typeof test.rawTx !== 'string') return null;
+  const data = parseTransaction(test.rawTx).data ?? '0x';
+  if (data.length < 10) throw new Error('calldata shorter than 4 bytes');
+  return slice(data, 0, 4);
+}
+
+// --- Check -------------------------------------------------------------------
+
+/**
+ * The errors of one descriptor, or null when there is nothing to check: the
+ * descriptor cannot be read (another job reports it), it formats no function,
+ * or it has no test file (the require-testsv2 job reports it).
+ */
+function checkDescriptor(descriptorAbs) {
+  const descriptor = rel(descriptorAbs);
+  const errors = [];
+
+  let formats;
+  try {
+    formats = resolveDescriptor(descriptorAbs).display?.formats ?? {};
+  } catch (error) {
+    // Another job reports the malformed descriptor; there is nothing to cover.
+    process.stderr.write(`warning: cannot read ${descriptor}: ${error.message}\n`);
+    return null;
+  }
+
+  const selectors = new Map(); // selector -> the keys that hash to it
+  for (const key of Object.keys(formats)) {
+    let selector;
+    try {
+      selector = selectorOf(key);
+    } catch (error) {
+      errors.push(`Cannot derive a selector from the format key ${JSON.stringify(key)}: ${reason(error)}`);
+      continue;
+    }
+    if (!selectors.has(selector)) selectors.set(selector, []);
+    selectors.get(selector).push(key);
+  }
+  if (selectors.size === 0 && errors.length === 0) return null;
+
+  const testFile = `${path.posix.dirname(descriptor)}/testsv2/${path.posix.basename(descriptor, '.json')}.tests.json`;
+  let tests;
+  try {
+    tests = JSON.parse(fs.readFileSync(path.join(repoRoot, testFile), 'utf8')).tests;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // require-testsv2 reports the missing file; it is a different fix.
+      process.stderr.write(`warning: ${descriptor} has no test file ${testFile}\n`);
+      return errors.length > 0 ? errors : null;
+    }
+    errors.push(`Cannot read ${testFile}: ${error.message}`);
+    return errors;
+  }
+  if (!Array.isArray(tests)) {
+    errors.push(`${testFile} has no "tests" array`);
+    return errors;
+  }
+
+  const covered = new Set();
+  tests.forEach((test, i) => {
+    try {
+      const selector = testSelector(test);
+      if (selector) covered.add(selector);
+    } catch (error) {
+      const name = test?.description ? JSON.stringify(test.description) : `#${i + 1}`;
+      errors.push(`Test ${name} in ${testFile} has a rawTx that cannot be decoded: ${reason(error)}`);
+    }
+  });
+
+  const uncovered = [...selectors].filter(([selector]) => !covered.has(selector));
+  if (uncovered.length > 0) {
+    const list = uncovered.map(([selector, keys]) => `${keys.join(' / ')} (${selector})`).join('; ');
+    errors.push(
+      `${uncovered.length} of ${selectors.size} function(s) have no test in ${testFile}. Add a test whose rawTx calls: ${list}`,
+    );
+  }
+  return errors;
+}
+
+function main() {
+  const targets = process.argv.slice(2);
+  if (targets.length === 0) {
+    process.stderr.write('Usage: node check-selector-coverage.js <descriptor.json|directory>...\n');
+    process.exit(2);
+  }
+
+  const descriptors = [...new Set(targets.flatMap((t) => collectDescriptors(path.resolve(t), [])))].sort();
+  let checked = 0;
+  let failed = 0;
+  for (const descriptorAbs of descriptors) {
+    const descriptor = rel(descriptorAbs);
+    if (!/^calldata-/.test(path.basename(descriptor))) continue;
+    const result = checkDescriptor(descriptorAbs);
+    if (result === null) {
+      console.log(`⏭️ ${descriptor} (nothing to check)`);
+      continue;
+    }
+    checked++;
+    if (result.length === 0) {
+      console.log(`✅ ${descriptor}`);
+      continue;
+    }
+    failed++;
+    for (const message of result) console.log(`::error file=${descriptor},line=1::${message}`);
+  }
+
+  const summary = `${failed} of ${checked} descriptor(s) have a function without a test.`;
+  console.log(summary);
+  if (process.env.GITHUB_STEP_SUMMARY && failed > 0) {
+    // GitHub shows 10 annotations per step, so give the total as well.
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary} See the log for the full list.\n`);
+  }
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { selectorOf, testSelector };

--- a/.github/workflows/clear-signing-tests-results.yml
+++ b/.github/workflows/clear-signing-tests-results.yml
@@ -44,6 +44,15 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download the test coverage report
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: test-coverage
+          path: test-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download the runner results
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -104,13 +113,14 @@ jobs:
               ctx = null;
             }
 
-            // Runner strings are untrusted. Keep them inside one table cell.
-            const cell = (v) =>
+            // Runner strings are untrusted. Keep them inside one line.
+            const line = (v) =>
               String(v ?? '')
                 .replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
                 .replace(/\|/g, '\\|')
-                .replace(/[\r\n]+/g, ' ')
-                .slice(0, 200);
+                .replace(/[\r\n]+/g, ' ');
+            // And inside one table cell.
+            const cell = (v) => line(v).slice(0, 200);
             const block = (v) => {
               const text = v != null ? JSON.stringify(v, null, 2) : '(none)';
               return text.length > 4000 ? `${text.slice(0, 4000)}\n… truncated` : text;
@@ -197,6 +207,23 @@ jobs:
               body +=
                 '\nCreate a test file at `registry/<entity>/testsv2/<descriptor-name>.tests.json`. ' +
                 'See [testing documentation](../blob/master/README.md#reference-test-cases) for details.\n\n';
+            }
+
+            // check-test-coverage already failed the run, like require-testsv2.
+            let coverage = {};
+            try {
+              coverage = JSON.parse(fs.readFileSync(path.join(workspace, 'test-coverage', 'coverage.json'), 'utf8'));
+            } catch {
+              // The job did not run, or the run failed before it.
+            }
+            const gaps = Object.entries(coverage);
+            if (gaps.length > 0) {
+              body += `❌ ${gaps.length} affected descriptor(s) failed the test coverage check:\n\n`;
+              for (const [descriptor, messages] of gaps) {
+                body += `- \`${cell(descriptor)}\`\n`;
+                for (const message of messages) body += `  - ${line(message).slice(0, 1000)}\n`;
+              }
+              body += '\n';
             }
 
             // No descriptor had a test file, so no runner produced anything.

--- a/.github/workflows/clear-signing-tests.yml
+++ b/.github/workflows/clear-signing-tests.yml
@@ -394,9 +394,7 @@ jobs:
   check-test-coverage:
     name: Check test coverage
     needs: detect-testsv2
-    # The script comes from the base, like the other scripts of this workflow,
-    # so the job is skipped until the script is on the base branch.
-    if: needs.detect-testsv2.outputs.has_tests == 'true' && hashFiles('base-scripts/.github/scripts/check-selector-coverage.js') != ''
+    if: needs.detect-testsv2.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -426,6 +424,10 @@ jobs:
         run: npm ci
 
       - name: Check that every function of an affected descriptor has a test
+        # The script comes from the base, like the other scripts of this
+        # workflow. hashFiles only works in a step condition, so the step, not
+        # the job, is skipped until the script is on the base branch.
+        if: hashFiles('base-scripts/.github/scripts/check-selector-coverage.js') != ''
         env:
           TEST_MATRIX: ${{ needs.detect-testsv2.outputs.test_matrix }}
         run: |
@@ -434,7 +436,7 @@ jobs:
             $(echo "$TEST_MATRIX" | jq -r '.[].descriptor')
 
       - name: Upload the coverage report
-        if: always()
+        if: always() && hashFiles('base-scripts/.github/scripts/check-selector-coverage.js') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-coverage

--- a/.github/workflows/clear-signing-tests.yml
+++ b/.github/workflows/clear-signing-tests.yml
@@ -391,6 +391,56 @@ jobs:
           entity: ${{ matrix.test.entity }}
           descriptor-name: ${{ matrix.test.descriptor_name }}
 
+  check-test-coverage:
+    name: Check test coverage
+    needs: detect-testsv2
+    # The script comes from the base, like the other scripts of this workflow,
+    # so the job is skipped until the script is on the base branch.
+    if: needs.detect-testsv2.outputs.has_tests == 'true' && hashFiles('base-scripts/.github/scripts/check-selector-coverage.js') != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout base scripts and their dependencies
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-scripts
+          sparse-checkout: |
+            .github/scripts
+            package.json
+            package-lock.json
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: base-scripts/package-lock.json
+
+      - name: Install the dependencies of the base scripts
+        working-directory: base-scripts
+        run: npm ci
+
+      - name: Check that every function of an affected descriptor has a test
+        env:
+          TEST_MATRIX: ${{ needs.detect-testsv2.outputs.test_matrix }}
+        run: |
+          node base-scripts/.github/scripts/check-selector-coverage.js \
+            --report test-coverage/coverage.json \
+            $(echo "$TEST_MATRIX" | jq -r '.[].descriptor')
+
+      - name: Upload the coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-coverage
+          path: test-coverage
+          retention-days: 30
+
   require-testsv2:
     name: Require testsv2 files
     needs: detect-testsv2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -214,6 +214,67 @@ jobs:
         # sync-indexes workflow — by then the conflict is already on master.
         run: node tools/scripts/generate-index.js --validate
 
+  validate_test_coverage:
+    name: 🔎 validate test coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        timeout-minutes: 10
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get all changed descriptor, shared and testsv2 files
+        timeout-minutes: 5
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: |
+            registry/**/*.json
+            ercs/**/*.json
+          files_ignore: |
+            registry/**/tests/**
+            registry/**/sigs/**
+
+      - name: Resolve affected descriptors
+        timeout-minutes: 5
+        id: affected-descriptors
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          DELETED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
+        run: |
+          # A changed shared file or testsv2 file affects the descriptors that
+          # include it or that it tests, so those are checked too.
+          RESULT=$(CHANGED_FILES="$CHANGED_FILES $DELETED_FILES" \
+            node .github/scripts/list-affected-descriptors.js)
+          echo "$RESULT" | jq .
+          echo "descriptors=$(echo "$RESULT" | jq -r '.affected_descriptors | join(" ")')" >> $GITHUB_OUTPUT
+          echo "any_affected=$(echo "$RESULT" | jq -r '.has_affected')" >> $GITHUB_OUTPUT
+
+      - name: Setup node
+        timeout-minutes: 10
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        timeout-minutes: 10
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
+        run: npm ci
+
+      - name: Check that every function of an affected descriptor has a test
+        timeout-minutes: 5
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
+        # The runners only exercise the functions that a fixture calls, so a
+        # format without a test is never checked against an implementation.
+        # The script derives the selector of each display format and looks
+        # for it in the first 4 bytes of the calldata of the testsv2 cases.
+        env:
+          AFFECTED_FILES: ${{ steps.affected-descriptors.outputs.descriptors }}
+        run: node .github/scripts/check-selector-coverage.js $AFFECTED_FILES
+
   validate_file_names:
     name: 🔎 validate file names
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -214,67 +214,6 @@ jobs:
         # sync-indexes workflow — by then the conflict is already on master.
         run: node tools/scripts/generate-index.js --validate
 
-  validate_test_coverage:
-    name: 🔎 validate test coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        timeout-minutes: 10
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Get all changed descriptor, shared and testsv2 files
-        timeout-minutes: 5
-        id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files: |
-            registry/**/*.json
-            ercs/**/*.json
-          files_ignore: |
-            registry/**/tests/**
-            registry/**/sigs/**
-
-      - name: Resolve affected descriptors
-        timeout-minutes: 5
-        id: affected-descriptors
-        if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-          DELETED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
-        run: |
-          # A changed shared file or testsv2 file affects the descriptors that
-          # include it or that it tests, so those are checked too.
-          RESULT=$(CHANGED_FILES="$CHANGED_FILES $DELETED_FILES" \
-            node .github/scripts/list-affected-descriptors.js)
-          echo "$RESULT" | jq .
-          echo "descriptors=$(echo "$RESULT" | jq -r '.affected_descriptors | join(" ")')" >> $GITHUB_OUTPUT
-          echo "any_affected=$(echo "$RESULT" | jq -r '.has_affected')" >> $GITHUB_OUTPUT
-
-      - name: Setup node
-        timeout-minutes: 10
-        if: steps.affected-descriptors.outputs.any_affected == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 10
-        if: steps.affected-descriptors.outputs.any_affected == 'true'
-        run: npm ci
-
-      - name: Check that every function of an affected descriptor has a test
-        timeout-minutes: 5
-        if: steps.affected-descriptors.outputs.any_affected == 'true'
-        # The runners only exercise the functions that a fixture calls, so a
-        # format without a test is never checked against an implementation.
-        # The script derives the selector of each display format and looks
-        # for it in the first 4 bytes of the calldata of the testsv2 cases.
-        env:
-          AFFECTED_FILES: ${{ steps.affected-descriptors.outputs.descriptors }}
-        run: node .github/scripts/check-selector-coverage.js $AFFECTED_FILES
-
   validate_file_names:
     name: 🔎 validate file names
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Test files should be placed in a `testsv2/` folder within your entity directory 
 
 ### Best practices
 
-1. **Include at least one test per function/message type** defined in your descriptor
+1. **Include at least one test per function/message type** defined in your descriptor. For calldata descriptors CI enforces this: it computes the 4-byte selector of every key in `display.formats` and compares it with the first 4 bytes of the calldata of each test case's `rawTx`. A function whose selector no test case contains fails the check.
 2. **Use real transactions** when possible - they provide the most realistic test cases
 3. **Add descriptive labels** to help reviewers understand what each test validates
 4. **Test edge cases** like maximum values, zero values, and special addresses

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ercs/
 - All ERC-7730 compatible files are prefixed with either `calldata` for smart contracts or `eip712` for EIP-712 messages.
 - All ERC-7730 compatible files are correctly validated against the schema file located at `specs/erc7730-v2.schema.json`.
 - Do not use the `calldata` or `eip712` prefixes for common files which are included by the ERC-7730 files and placed at the top level of the entity folder. Name them `common-*.json` instead.
-- Each descriptor added or changed is accompanied by a test file so descriptors can be verified against the formatter implementations. See [Reference test cases](#reference-test-cases).
+- Each descriptor added or changed is accompanied by a test file so descriptors can be verified against the formatter implementations. For a calldata descriptor, the test file has at least one test case for every function in `display.formats`: CI derives the selector of each format and looks for it in the calldata of the test cases. See [Reference test cases](#reference-test-cases).
 
 Reviewers check each PR against the [review guidelines](docs/REVIEWING.md).
 
@@ -195,7 +195,7 @@ Test files should be placed in a `testsv2/` folder within your entity directory 
 
 ### Best practices
 
-1. **Include at least one test per function/message type** defined in your descriptor. For calldata descriptors CI enforces this: it computes the 4-byte selector of every key in `display.formats` and compares it with the first 4 bytes of the calldata of each test case's `rawTx`. A function whose selector no test case contains fails the check.
+1. **Include at least one test per function/message type** defined in your descriptor
 2. **Use real transactions** when possible - they provide the most realistic test cases
 3. **Add descriptive labels** to help reviewers understand what each test validates
 4. **Test edge cases** like maximum values, zero values, and special addresses

--- a/docs/REVIEWING.md
+++ b/docs/REVIEWING.md
@@ -10,7 +10,7 @@ A PR review is deliberately **short and basic**: the mechanical rules are enforc
 
 ### 1. Are all CI checks green?
 
-Nothing gets merged with failing checks. CI covers the mechanical review completely — linting and schema validation, test presence and results, index collisions (no hijacking of another project's deployments), file naming, and immutability of attested descriptors. None of these needs a manual pass anymore.
+Nothing gets merged with failing checks. CI covers the mechanical review completely — linting and schema validation, test presence, results and coverage (every function of a calldata descriptor has a test case), index collisions (no hijacking of another project's deployments), file naming, and immutability of attested descriptors. None of these needs a manual pass anymore.
 
 The optional improvements (adding `interpolatedIntent`, dropping deprecated fields) are also suggested automatically by the advisory **recommendations comment** — nothing to do there either; whether the author applies them is their call.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,16 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "js-sha3": "^0.9.3"
+        "js-sha3": "^0.9.3",
+        "viem": "^2.56.3"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.74.0",
@@ -231,6 +239,87 @@
         "@langchain/core": "^1.1.30"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -245,6 +334,28 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -328,6 +439,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/js-sha3": {
@@ -429,6 +556,44 @@
         }
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.44",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.44.tgz",
+      "integrity": "sha512-O54qXXHEk4ySamMSyBpI0AeBegS5frxU6+LA6Jb9Sf6kMOxcTNaxYmwZfpOu22DIQsdKfgQxHq8EsAGaoBQScA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -508,6 +673,59 @@
       ],
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.56.3.tgz",
+      "integrity": "sha512-vUObq3GO7D3lz9gPNEE/xd5jIUnMbeVDWewh252o54pDEDlW4pDe6FEd/qTGL5RyK52cGHMM7kQ3wjxhilEvkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.44",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "generate-index": "node tools/scripts/generate-index.js"
   },
   "devDependencies": {
-    "js-sha3": "^0.9.3"
+    "js-sha3": "^0.9.3",
+    "viem": "^2.56.3"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.3.22",


### PR DESCRIPTION
Closes #2964.

## What

A new `check-test-coverage` job in `clear-signing-tests.yml`, next to `require-testsv2`, runs `.github/scripts/check-selector-coverage.js` on the affected descriptors that have a test file. For each one the script resolves `includes`, computes the 4-byte selector of every `display.formats` key, decodes every `rawTx` of the matching `testsv2` file and takes the first 4 bytes of its calldata. A format whose selector no test contains fails the job with an annotation on the descriptor that names the missing functions and their selectors, and the results comment lists the gaps next to the missing test files.

## How

- The job consumes the `test_matrix` output of `detect-testsv2`, so it only sees descriptors with a test file and does not repeat the changed-files step.
- Like the rest of the workflow it runs the script from the base branch, behind a `hashFiles` guard so this pull request passes with the job skipped. The base sparse checkout includes `package.json` and the lockfile, and `npm ci` runs inside it, so the base script gets the base dependencies.
- viem does the parsing on both sides: `parseAbiItem` plus `toFunctionSelector` for the format keys (parameter names stripped, `uint` expanded to `uint256`, tuples handled) and `parseTransaction` for the fixtures (legacy and typed envelopes, signed or unsigned). It is added as a devDependency.
- The script also fails on a test without `rawTx`, a test whose selector matches no format of the descriptor, a fixture whose `descriptor` field names another descriptor, a fixture that cannot be decoded, a format key that is not a function signature, and a descriptor that cannot be read or resolved. EIP-712 descriptors are skipped.
- The job uploads a JSON report as the `test-coverage` artifact; `clear-signing-tests-results.yml` renders it in the pull request comment.

## Verification

- All 605 calldata fixtures in the registry decode, every one of their selectors matches a format of its descriptor, and every fixture names its own descriptor.
- A full-registry run reports 117 of 190 tested calldata descriptors with at least one untested function. Those are existing gaps, and they only fail the job once someone touches the descriptor, same as require-testsv2.
- The job is skipped on this pull request, so the comment rendering was checked locally by running the workflow's inline script against mocked GitHub calls, a context and a coverage report.

## Docs

The "Pull Request content requirements" section of the README and `docs/REVIEWING.md` mention the new check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
