### PR TITLE
fix(swell): show unlimited allowances as "Unlimited"

### DIFF
--- a/registry/swell/calldata-swell.json
+++ b/registry/swell/calldata-swell.json
@@ -23,7 +23,16 @@
         "intent": "Approve spender",
         "fields": [
           { "label": "Spender", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] }, "path": "#.spender" },
-          { "label": "Amount", "format": "tokenAmount", "path": "amount", "params": { "token": "$.metadata.constants.swellToken" } }
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "amount",
+            "params": {
+              "token": "$.metadata.constants.swellToken",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            }
+          }
         ]
       },
       "batchAddToWhitelist(address[] _addresses)": {
@@ -75,7 +84,16 @@
         "intent": "Increase allowance",
         "fields": [
           { "label": "Spender", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] }, "path": "#.spender" },
-          { "label": "Added Value", "format": "tokenAmount", "path": "#.addedValue", "params": { "tokenPath": "@.to" } }
+          {
+            "label": "Added Value",
+            "format": "tokenAmount",
+            "path": "#.addedValue",
+            "params": {
+              "tokenPath": "@.to",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            }
+          }
         ]
       },
       "removeFromWhitelist(address _address)": {

--- a/registry/swell/testsv2/calldata-swell.tests.json
+++ b/registry/swell/testsv2/calldata-swell.tests.json
@@ -22,6 +22,16 @@
         "owner": "Swell",
         "fields": [{ "label": "To", "value": "0x7e702F7A8299b51D3Eb0A3E8107Ce64f7D726966" }, { "label": "Amount", "value": "0.8856 rswETH" }]
       }
+    },
+    {
+      "description": "Approve spender unlimited - chain 1",
+      "rawTx": "0x02f86d016a8424eec95a84299c0bb483013c3894fae103dc9cf190ed75350761e95403b7b8afa6c080b844095ea7b300000000000000000000000040aa958dd87fc8305b97f2ba922cddca374bcd7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0",
+      "txHash": "0x1b3e99df256414854cddd9ab688554066e1c66e0494c50a6c172ad99031e5de5",
+      "expected": {
+        "intent": "Approve spender",
+        "owner": "Swell",
+        "fields": [{ "label": "Spender", "value": "0x40aA958dd87FC8305b97f2BA922CDdCa374bcD7f" }, { "label": "Amount", "value": "Unlimited rswETH" }]
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #2815 — Cyfrin audit, Medium.

`approve` and `increaseAllowance` on `calldata-swell.json` had no `threshold`, so `type(uint256).max` rendered as a 78-digit integer instead of `Unlimited`. An unlimited allowance is the highest-persistence permission a user can grant, and it should be recognisable at a glance rather than looking like an oddly large finite amount.

## The change

Adds `threshold` and `message` to the amount field of both formats. Two entries touched, nothing else.

## A deliberate deviation from the suggested diff

The issue's recommended mitigation uses `0xffff…ffff` (`type(uint256).max`). I used **`0x8000…0000` (2^255)** instead, for two reasons:

1. **It is the registry's established convention.** `ercs/eip712-erc2612-permit.json` — the shared file that #2853 used to clear 74 findings of this exact kind — uses 2^255, as do 15 other descriptors. Only 2 use a max-uint256-style value.
2. **It catches more of the real cases.** A threshold is a floor, not an equality check. At 2^255 an allowance that is effectively unlimited but not exactly `type(uint256).max` still renders as `Unlimited`; at max-uint256 it would display as a 78-digit number and the finding would remain open in practice.

Happy to switch to the literal value from the issue if reviewers prefer the audit text verbatim.

## `decreaseAllowance` deliberately left alone

It has the same missing `threshold`, but the audit did not flag it and I think that is right: an unlimited *decrease* clears an allowance rather than granting one, so `Unlimited` there would describe a safe action in the language used for a dangerous one.

## Test

Added a reference test built from a real mainnet unlimited approve — [`0x1b3e99df…`](https://etherscan.io/tx/0x1b3e99df256414854cddd9ab688554066e1c66e0494c50a6c172ad99031e5de5), an exact `type(uint256).max` approval:

| Test | Amount renders as |
|---|---|
| Approve spender (existing) | `0.25 rswETH` |
| Transfer Tokens (existing) | `0.8856 rswETH` |
| **Approve spender unlimited (new)** | **`Unlimited rswETH`** |

The two existing cases are finite and unaffected, so they also serve as a regression check that ordinary amounts still render normally.

## Validation

```
erc7730 lint registry/swell/calldata-swell.json   -> 0 errors
erc7730 format registry/swell/calldata-swell.json -> no issue found
```

Both files validate against `specs/erc7730-v2.schema.json` and `specs/erc7730-tests-v2.schema.json`. The formatter expanded the two edited entries to multiple lines — that is `erc7730 format`'s own output for the longer params, not a hand reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)