### PR TITLE
fix(opensea): make the Wyvern order screen state what is authorized

### DIFF
--- a/registry/opensea/eip712-opensea.json
+++ b/registry/opensea/eip712-opensea.json
@@ -6,35 +6,91 @@
       "domain": { "name": "Wyvern Exchange Contract", "version": "2.3" }
     }
   },
-  "metadata": { "owner": "Wyvern Exchange Contract" },
+  "metadata": {
+    "owner": "Wyvern Exchange Contract",
+    "enums": {
+      "side": { "0": "Buy", "1": "Sell" },
+      "saleKind": { "0": "Fixed price", "1": "Dutch auction" },
+      "howToCall": { "0": "Call", "1": "DelegateCall" }
+    }
+  },
   "display": {
     "formats": {
       "Order(address exchange,address maker,address taker,uint256 makerRelayerFee,uint256 takerRelayerFee,uint256 makerProtocolFee,uint256 takerProtocolFee,address feeRecipient,uint8 feeMethod,uint8 side,uint8 saleKind,address target,uint8 howToCall,bytes calldata,bytes replacementPattern,address staticTarget,bytes staticExtradata,address paymentToken,uint256 basePrice,uint256 extra,uint256 listingTime,uint256 expirationTime,uint256 salt,uint256 nonce)": {
-        "intent": "OpenSea Listing",
+        "intent": "Sign Wyvern order",
         "fields": [
-          { "path": "exchange", "label": "Contract address", "format": "raw" },
-          { "path": "basePrice", "label": "Price", "format": "raw" },
-          { "path": "expirationTime", "label": "Offer expiration", "format": "raw" },
-          { "label": "Side", "path": "side", "visible": "never" },
-          { "label": "Extra", "path": "extra", "visible": "never" },
-          { "label": "Sale Kind", "path": "saleKind", "visible": "never" },
-          { "label": "Static Target", "path": "staticTarget", "visible": "never" },
-          { "label": "Target", "path": "target", "visible": "never" },
-          { "label": "How To Call", "path": "howToCall", "visible": "never" },
-          { "label": "Maker Relayer Fee", "path": "makerRelayerFee", "visible": "never" },
-          { "label": "Fee Method", "path": "feeMethod", "visible": "never" },
-          { "label": "Replacement Pattern", "path": "replacementPattern", "visible": "never" },
-          { "label": "Taker Relayer Fee", "path": "takerRelayerFee", "visible": "never" },
-          { "label": "Taker", "path": "taker", "visible": "never" },
-          { "label": "Listing Time", "path": "listingTime", "visible": "never" },
-          { "label": "Static Extradata", "path": "staticExtradata", "visible": "never" },
-          { "label": "Maker Protocol Fee", "path": "makerProtocolFee", "visible": "never" },
-          { "label": "Taker Protocol Fee", "path": "takerProtocolFee", "visible": "never" },
-          { "label": "Payment Token", "path": "paymentToken", "visible": "never" },
-          { "label": "Calldata", "path": "calldata", "visible": "never" },
-          { "label": "Salt", "path": "salt", "visible": "never" },
-          { "label": "Fee Recipient", "path": "feeRecipient", "visible": "never" },
-          { "label": "Maker", "path": "maker", "visible": "never" }
+          {
+            "path": "side",
+            "label": "Order side",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.side" },
+            "visible": "always"
+          },
+          {
+            "path": "saleKind",
+            "label": "Sale kind",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.saleKind" },
+            "visible": "always"
+          },
+          {
+            "path": "basePrice",
+            "label": "Price",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "paymentToken" },
+            "visible": "always"
+          },
+          {
+            "path": "maker",
+            "label": "Maker",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "taker",
+            "label": "Taker",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "target",
+            "label": "Asset contract",
+            "format": "addressName",
+            "params": { "types": ["contract", "collection", "token"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "howToCall",
+            "label": "Execution mode",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.howToCall" },
+            "visible": "always"
+          },
+          { "path": "calldata", "label": "Executed calldata", "format": "raw", "visible": "always" },
+          { "path": "replacementPattern", "label": "Rewritable bytes", "format": "raw", "visible": "always" },
+          {
+            "path": "listingTime",
+            "label": "Listing time",
+            "format": "date",
+            "params": { "encoding": "timestamp" },
+            "visible": "always"
+          },
+          { "path": "expirationTime", "label": "Expires", "format": "date", "params": { "encoding": "timestamp" }, "visible": "always" },
+          { "path": "exchange", "label": "Exchange", "visible": "never" },
+          { "path": "makerRelayerFee", "label": "Maker Relayer Fee", "visible": "never" },
+          { "path": "takerRelayerFee", "label": "Taker Relayer Fee", "visible": "never" },
+          { "path": "makerProtocolFee", "label": "Maker Protocol Fee", "visible": "never" },
+          { "path": "takerProtocolFee", "label": "Taker Protocol Fee", "visible": "never" },
+          { "path": "feeRecipient", "label": "Fee Recipient", "visible": "never" },
+          { "path": "feeMethod", "label": "Fee Method", "visible": "never" },
+          { "path": "staticTarget", "label": "Static Target", "visible": "never" },
+          { "path": "staticExtradata", "label": "Static Extradata", "visible": "never" },
+          { "path": "paymentToken", "label": "Payment Token", "visible": "never" },
+          { "path": "extra", "label": "Extra", "visible": "never" },
+          { "path": "salt", "label": "Salt", "visible": "never" },
+          { "path": "nonce", "label": "Nonce", "visible": "never" }
         ]
       }
     }

--- a/registry/opensea/testsv2/eip712-opensea.tests.json
+++ b/registry/opensea/testsv2/eip712-opensea.tests.json
@@ -1,9 +1,10 @@
 {
   "$schema": "../../../specs/erc7730-tests-v2.schema.json",
   "descriptor": "../eip712-opensea.json",
+  "dataProvider": { "tokens": { "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": { "symbol": "WETH", "decimals": 18, "name": "Wrapped Ether" } } },
   "tests": [
     {
-      "description": "OpenSea Listing",
+      "description": "Wyvern sell order, fixed price - chain 1",
       "data": {
         "types": {
           "EIP712Domain": [
@@ -74,12 +75,109 @@
         }
       },
       "expected": {
-        "intent": "OpenSea Listing",
+        "intent": "Sign Wyvern order",
         "owner": "Wyvern Exchange Contract",
         "fields": [
-          { "label": "Contract address", "value": "0x7f268357A8c2552623316e2562D90e642bB538E5" },
-          { "label": "Price", "value": "7500000000000000000" },
-          { "label": "Offer expiration", "value": "1775174400" }
+          { "label": "Order side", "value": "Sell" },
+          { "label": "Sale kind", "value": "Fixed price" },
+          { "label": "Price", "value": "7.5 WETH" },
+          { "label": "Maker", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+          { "label": "Taker", "value": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e" },
+          { "label": "Asset contract", "value": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D" },
+          { "label": "Execution mode", "value": "Call" },
+          { "label": "Executed calldata", "value": "0x23b872dd000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e00000000000000000000000000000000000000000000000000000000000004d2" },
+          { "label": "Rewritable bytes", "value": "0x" },
+          { "label": "Listing time", "value": "2026-03-20 00:00:00Z" },
+          { "label": "Expires", "value": "2026-04-03 00:00:00Z" }
+        ]
+      }
+    },
+    {
+      "description": "Wyvern buy order, delegatecall - chain 1",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Order": [
+            { "name": "exchange", "type": "address" },
+            { "name": "maker", "type": "address" },
+            { "name": "taker", "type": "address" },
+            { "name": "makerRelayerFee", "type": "uint256" },
+            { "name": "takerRelayerFee", "type": "uint256" },
+            { "name": "makerProtocolFee", "type": "uint256" },
+            { "name": "takerProtocolFee", "type": "uint256" },
+            { "name": "feeRecipient", "type": "address" },
+            { "name": "feeMethod", "type": "uint8" },
+            { "name": "side", "type": "uint8" },
+            { "name": "saleKind", "type": "uint8" },
+            { "name": "target", "type": "address" },
+            { "name": "howToCall", "type": "uint8" },
+            { "name": "calldata", "type": "bytes" },
+            { "name": "replacementPattern", "type": "bytes" },
+            { "name": "staticTarget", "type": "address" },
+            { "name": "staticExtradata", "type": "bytes" },
+            { "name": "paymentToken", "type": "address" },
+            { "name": "basePrice", "type": "uint256" },
+            { "name": "extra", "type": "uint256" },
+            { "name": "listingTime", "type": "uint256" },
+            { "name": "expirationTime", "type": "uint256" },
+            { "name": "salt", "type": "uint256" },
+            { "name": "nonce", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Order",
+        "domain": {
+          "name": "Wyvern Exchange Contract",
+          "version": "2.3",
+          "chainId": 1,
+          "verifyingContract": "0x7f268357A8c2552623316e2562D90e642bB538E5"
+        },
+        "message": {
+          "exchange": "0x7f268357A8c2552623316e2562D90e642bB538E5",
+          "maker": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "taker": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "makerRelayerFee": "250",
+          "takerRelayerFee": "0",
+          "makerProtocolFee": "0",
+          "takerProtocolFee": "0",
+          "feeRecipient": "0x5b3256965E7C3CF26E11FcAF296dFfC8807C0107",
+          "feeMethod": 1,
+          "side": 0,
+          "saleKind": 1,
+          "target": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "howToCall": 1,
+          "calldata": "0x23b872dd000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e00000000000000000000000000000000000000000000000000000000000004d2",
+          "replacementPattern": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "staticTarget": "0x7f268357A8c2552623316e2562D90e642bB538E5",
+          "staticExtradata": "0x",
+          "paymentToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "basePrice": "1250000000000000000",
+          "extra": "0",
+          "listingTime": "1773964800",
+          "expirationTime": "1775174400",
+          "salt": "5512094834578234509823450982345098",
+          "nonce": "7"
+        }
+      },
+      "expected": {
+        "intent": "Sign Wyvern order",
+        "owner": "Wyvern Exchange Contract",
+        "fields": [
+          { "label": "Order side", "value": "Buy" },
+          { "label": "Sale kind", "value": "Dutch auction" },
+          { "label": "Price", "value": "1.25 WETH" },
+          { "label": "Maker", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+          { "label": "Taker", "value": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e" },
+          { "label": "Asset contract", "value": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D" },
+          { "label": "Execution mode", "value": "DelegateCall" },
+          { "label": "Executed calldata", "value": "0x23b872dd000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e00000000000000000000000000000000000000000000000000000000000004d2" },
+          { "label": "Rewritable bytes", "value": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" },
+          { "label": "Listing time", "value": "2026-03-20 00:00:00Z" },
+          { "label": "Expires", "value": "2026-04-03 00:00:00Z" }
         ]
       }
     }


### PR DESCRIPTION
Closes #2665 — Cyfrin audit, and the audit's only **Critical**.

## The problem

The screen showed three fields under a fixed intent of `OpenSea Listing`:

```
OpenSea Listing
Contract address   0x7f268357A8c2552623316e2562D90e642bB538E5
Price              7500000000000000000
Offer expiration   1775174400
```

Everything that defines the order's effect was `visible: never` — `side`, `saleKind`, `howToCall`, `target`, `calldata`, `replacementPattern`, `paymentToken`, `maker`, `taker`.

The consequences are what make this Critical rather than cosmetic:

- **A buy renders identically to a sell.** `side` was hidden, but the intent asserted "Listing". The screen could state the opposite of what was being signed.
- **A `DelegateCall` order renders identically to a `Call` order.** `howToCall` was hidden.
- **The currency was invisible.** `basePrice` was `raw`, so 7.5 WETH and 7.5 ETH looked the same.
- **The asset was invisible.** `target` and `calldata` — which actually move the NFT — were both hidden.

## Why fix rather than remove

The issue offers removing the `Order` format as an alternative if the transfer cannot be decoded well enough. I checked whether Wyvern is still live before choosing:

```
atomicMatch_   2025-12-19
atomicMatch_   2025-10-11
atomicMatch_   2025-09-23
```

Residual but real usage. Removing the descriptor would push those signers back to full blind signing, which is strictly worse than an honest partial screen. So this fixes the display instead — with the important change that the screen no longer *claims* to know what the order is.

## The change

Intent becomes the neutral **"Sign Wyvern order"** rather than asserting a listing, and 11 decision-relevant fields become visible:

| Field | Format | Was |
|---|---|---|
| Order side | `enum` → Buy / Sell | hidden |
| Sale kind | `enum` → Fixed price / Dutch auction | hidden |
| Price | `tokenAmount` via `tokenPath: paymentToken` | `raw` integer |
| Maker / Taker | `addressName` | hidden |
| Asset contract | `addressName` | hidden |
| Execution mode | `enum` → Call / **DelegateCall** | hidden |
| Executed calldata | `raw`, visible | hidden |
| Rewritable bytes | `raw`, visible | hidden |
| Listing time / Expires | `date` | `raw` timestamp / hidden |

Two conventions borrowed from existing descriptors rather than invented: `metadata.enums` with `$ref` follows `aave/calldata-lpv2.json`, and `tokenAmount` + `tokenPath` pointing at another message field follows `1inch/eip712-1inch-limit-order.json`. Price now carries its own ticker, so the payment token is rendered without spending a separate screen on it.

`calldata` and `replacementPattern` are shown as `raw`. A descriptor cannot decode arbitrary nested calldata, but a signer seeing a non-empty replacement pattern at least knows the executed payload can be rewritten — which is invisible today.

## Left hidden, deliberately

Fees, `salt`, `nonce`, `staticTarget`, `staticExtradata`, and `extra`. `extra` is the Dutch-auction price delta and is arguably decision-relevant when `saleKind` is `Dutch auction`; I left it out to keep this change to the audit's stated list and to hold the screen count down. Happy to add it if reviewers want the auction terms complete.

## Tests

The existing case is re-expected against the new display. A second case is added for the scenario the finding describes — **a buy order that delegatecalls, with a non-empty replacement pattern**:

| | Case 1 | Case 2 |
|---|---|---|
| Order side | Sell | **Buy** |
| Sale kind | Fixed price | Dutch auction |
| Execution mode | Call | **DelegateCall** |
| Rewritable bytes | `0x` | `0xffff…ffff` |
| Price | 7.5 WETH | 1.25 WETH |

Under the previous descriptor **both of these rendered the same three lines** and both said "OpenSea Listing". That is the regression this is meant to prevent.

## Validation

```
erc7730 lint registry/opensea/eip712-opensea.json   -> 0 errors
erc7730 format registry/opensea/eip712-opensea.json -> no issue found
```

Both files validate against `specs/erc7730-v2.schema.json` and `specs/erc7730-tests-v2.schema.json`. The one remaining lint warning (`owner` exceeds 22 characters) pre-dates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)