### PR TITLE
fix(degate): correct the EIP-712 domain version and name the actions

### DIFF
--- a/registry/degate/eip712-degate.json
+++ b/registry/degate/eip712-degate.json
@@ -3,20 +3,23 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 1, "address": "0xe63602a9b3dfe983187525ac985fec4f57b24ed5" }],
-      "domain": { "name": "DeGate Protocol", "version": "3.0.1" }
+      "domain": { "name": "DeGate Protocol", "version": "0.1.0" }
     }
   },
-  "metadata": { "owner": "DeGate Exchange Contract" },
+  "metadata": {
+    "owner": "DeGate Exchange Contract",
+    "enums": { "tokenID": { "0": "ETH", "1": "DG", "2": "USDC", "3": "USDT", "4": "WBTC", "5": "DAI" } }
+  },
   "display": {
     "formats": {
       "AccountUpdate(address owner,uint32 accountID,uint32 feeTokenID,uint96 maxFee,uint256 publicKey,uint32 validUntil,uint32 nonce)": {
-        "intent": "DeGate AccountUpdate",
+        "intent": "Replace account signing key",
         "fields": [
           { "path": "owner", "label": "Owner", "format": "raw" },
           { "path": "accountID", "label": "AccountID", "format": "raw" },
-          { "path": "feeTokenID", "label": "FeeTokenID", "format": "raw" },
-          { "path": "maxFee", "label": "MaxFee", "format": "raw" },
-          { "path": "publicKey", "label": "PublicKey", "format": "raw" },
+          { "path": "feeTokenID", "label": "Fee token", "format": "enum", "params": { "$ref": "$.metadata.enums.tokenID" } },
+          { "path": "maxFee", "label": "Max fee (base units)", "format": "raw" },
+          { "path": "publicKey", "label": "New signing key", "format": "raw" },
           { "path": "validUntil", "label": "ValidUntil", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" }
         ]
@@ -26,10 +29,10 @@
         "fields": [
           { "path": "owner", "label": "Owner", "format": "raw" },
           { "path": "accountID", "label": "AccountID", "format": "raw" },
-          { "path": "tokenID", "label": "TokenID", "format": "raw" },
-          { "path": "amount", "label": "Amount", "format": "raw" },
-          { "path": "feeTokenID", "label": "FeeTokenID", "format": "raw" },
-          { "path": "maxFee", "label": "MaxFee", "format": "raw" },
+          { "path": "tokenID", "label": "Token", "format": "enum", "params": { "$ref": "$.metadata.enums.tokenID" } },
+          { "path": "amount", "label": "Amount (base units)", "format": "raw" },
+          { "path": "feeTokenID", "label": "Fee token", "format": "enum", "params": { "$ref": "$.metadata.enums.tokenID" } },
+          { "path": "maxFee", "label": "Max fee (base units)", "format": "raw" },
           { "path": "to", "label": "To", "format": "raw" },
           { "path": "minGas", "label": "MinGas", "format": "raw" },
           { "path": "validUntil", "label": "ValidUntil", "format": "raw" },
@@ -41,10 +44,10 @@
         "fields": [
           { "path": "owner", "label": "Owner", "format": "raw" },
           { "path": "accountID", "label": "AccountID", "format": "raw" },
-          { "path": "tokenID", "label": "TokenID", "format": "raw" },
-          { "path": "amount", "label": "Amount", "format": "raw" },
-          { "path": "feeTokenID", "label": "FeeTokenID", "format": "raw" },
-          { "path": "maxFee", "label": "MaxFee", "format": "raw" },
+          { "path": "tokenID", "label": "Token", "format": "enum", "params": { "$ref": "$.metadata.enums.tokenID" } },
+          { "path": "amount", "label": "Amount (base units)", "format": "raw" },
+          { "path": "feeTokenID", "label": "Fee token", "format": "enum", "params": { "$ref": "$.metadata.enums.tokenID" } },
+          { "path": "maxFee", "label": "Max fee (base units)", "format": "raw" },
           { "path": "to", "label": "To", "format": "raw" },
           { "path": "validUntil", "label": "ValidUntil", "format": "raw" },
           { "path": "storageID", "label": "StorageID", "format": "raw" }

--- a/registry/degate/tests/eip712-degate.tests.json
+++ b/registry/degate/tests/eip712-degate.tests.json
@@ -24,7 +24,7 @@
         "primaryType": "AccountUpdate",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },
@@ -81,7 +81,7 @@
         "primaryType": "Withdrawal",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },
@@ -147,7 +147,7 @@
         "primaryType": "Transfer",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },

--- a/registry/degate/testsv2/eip712-degate.tests.json
+++ b/registry/degate/testsv2/eip712-degate.tests.json
@@ -25,7 +25,7 @@
         "primaryType": "AccountUpdate",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },
@@ -40,14 +40,14 @@
         }
       },
       "expected": {
-        "intent": "DeGate AccountUpdate",
+        "intent": "Replace account signing key",
         "owner": "DeGate Exchange Contract",
         "fields": [
           { "label": "Owner", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
           { "label": "AccountID", "value": "10356" },
-          { "label": "FeeTokenID", "value": "0" },
-          { "label": "MaxFee", "value": "1000000000000000000" },
-          { "label": "PublicKey", "value": "21888242871839275222246405745257275088548364400416034343698204186575808495617" },
+          { "label": "Fee token", "value": "ETH" },
+          { "label": "Max fee (base units)", "value": "1000000000000000000" },
+          { "label": "New signing key", "value": "21888242871839275222246405745257275088548364400416034343698204186575808495617" },
           { "label": "ValidUntil", "value": "1742169600" },
           { "label": "Nonce", "value": "7" }
         ]
@@ -79,7 +79,7 @@
         "primaryType": "Withdrawal",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },
@@ -102,10 +102,10 @@
         "fields": [
           { "label": "Owner", "value": "0x36B2e1b2E6f6F2B82bAa2E4837F6b0De58Ae9815" },
           { "label": "AccountID", "value": "10425" },
-          { "label": "TokenID", "value": "0" },
-          { "label": "Amount", "value": "1500000000000000000" },
-          { "label": "FeeTokenID", "value": "2" },
-          { "label": "MaxFee", "value": "3000000000000000" },
+          { "label": "Token", "value": "ETH" },
+          { "label": "Amount (base units)", "value": "1500000000000000000" },
+          { "label": "Fee token", "value": "USDC" },
+          { "label": "Max fee (base units)", "value": "3000000000000000" },
           { "label": "To", "value": "0x36B2e1b2E6f6F2B82bAa2E4837F6b0De58Ae9815" },
           { "label": "MinGas", "value": "100000" },
           { "label": "ValidUntil", "value": "1774000000" },
@@ -138,7 +138,7 @@
         "primaryType": "Transfer",
         "domain": {
           "name": "DeGate Protocol",
-          "version": "3.0.1",
+          "version": "0.1.0",
           "chainId": 1,
           "verifyingContract": "0xe63602a9B3DFe983187525AC985Fec4F57B24eD5"
         },
@@ -160,10 +160,10 @@
         "fields": [
           { "label": "Owner", "value": "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf" },
           { "label": "AccountID", "value": "10425" },
-          { "label": "TokenID", "value": "0" },
-          { "label": "Amount", "value": "1500000000000000000" },
-          { "label": "FeeTokenID", "value": "0" },
-          { "label": "MaxFee", "value": "500000000000000" },
+          { "label": "Token", "value": "ETH" },
+          { "label": "Amount (base units)", "value": "1500000000000000000" },
+          { "label": "Fee token", "value": "ETH" },
+          { "label": "Max fee (base units)", "value": "500000000000000" },
           { "label": "To", "value": "0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF" },
           { "label": "ValidUntil", "value": "1773765209" },
           { "label": "StorageID", "value": "58" }


### PR DESCRIPTION
Closes #2641 — Cyfrin audit, 1 High and 2 Medium.

## 1. The domain version — High

The descriptor declared `version: "3.0.1"`. The deployed exchange signs over `"0.1.0"`, so **the descriptor never matched a real request** and every DeGate signer fell back to blind signing — on the three operations that replace the account signing key and move funds.

I verified this on-chain rather than taking the issue's word for it. The exchange at [`0xe63602a9…24eD5`](https://etherscan.io/address/0xe63602a9b3dfe983187525ac985fec4f57b24ed5) reports:

```
version()          -> "0.1.0"
domainSeparator()  -> 0x5630f2c00e81e2223458dcd1f7c1a754cd6cc2a258d90b829e325489c7002912
```

Recomputing the standard four-field `EIP712Domain` separator for `name = "DeGate Protocol"`, `chainId = 1`, `verifyingContract = 0xe63602a9…`:

| version | computed separator | matches chain? |
|---|---|---|
| **`0.1.0`** | `0x5630f2c0…02912` | ✅ **exact match** |
| `3.0.1` | `0xdc2b6f08…8c9e8` | ❌ |

The three `testsv2` fixtures are updated to the same version.

## 2. Naming the account-key replacement — Medium

`AccountUpdate` is the highest-risk operation in the set and was presented as a bare type name with the decisive value as an opaque integer.

- intent: `DeGate AccountUpdate` → **`Replace account signing key`**
- `publicKey` label: `PublicKey` → **`New signing key`**

## 3. Naming the asset — Medium

`tokenID` and `feeTokenID` now render through `metadata.enums` instead of a bare index, and the base-unit amounts say so:

| Field | Was | Now |
|---|---|---|
| `tokenID` / `feeTokenID` | `raw` → `0` | `enum` → `ETH` |
| `amount` | `Amount` | `Amount (base units)` |
| `maxFee` | `MaxFee` | `Max fee (base units)` |

**A correction to the issue's suggested diff.** It proposes `{ "0": "ETH", "1": "LRC" }`. On this exchange index 1 is not LRC. I read the table from `getTokenAddress(uint32)`:

| tokenID | address | symbol |
|---|---|---|
| 0 | `0x0000…0000` | ETH (native) |
| 1 | `0x53C8395465A84955c95159814461466053DedEDE` | **DG** |
| 2 | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | USDC |
| 3 | `0xdAC17F958D2ee523a2206206994597C13D831ec7` | USDT |
| 4 | `0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599` | WBTC |
| 5 | `0x6B175474E89094C44Da98b954EedeAC495271d0F` | DAI |

Taking the suggestion literally would have put a false token name on the screen, which is worse than the raw index it replaces. The enum ships the six verified indices only.

The differing decimals across these tokens (6, 8, 18) are also why the amount labels say *base units* — the token address is not in the message, so a true `tokenAmount` is not available from the message alone.

## Notes

- The issue suggests the label `New account signing key`, but `erc7730 lint` caps labels at 20 characters and that is 23, so it is shortened to `New signing key`.
- The legacy `tests/` fixture carried the same impossible domain. It asserts nothing, so it could not fail, but leaving `3.0.1` there would contradict the descriptor — corrected too.
- `validUntil` still renders as a raw timestamp rather than a date. Not part of this finding, so left alone; happy to include it if reviewers want.

## Validation

```
erc7730 lint registry/degate/eip712-degate.json   -> 0 errors
erc7730 format registry/degate/eip712-degate.json -> no issue found
```

Both files validate against `specs/erc7730-v2.schema.json` and `specs/erc7730-tests-v2.schema.json`. The remaining lint warning (`owner` exceeds 22 characters) pre-dates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)