### PR TITLE
Add Mandate x402 batch-settlement descriptors (Base Sepolia)

### DIFF
--- a/registry/mandate/eip712-x402-BatchSettlement.json
+++ b/registry/mandate/eip712-x402-BatchSettlement.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "x402BatchSettlement",
+    "eip712": {
+      "domain": {
+        "name": "x402 Batch Settlement",
+        "version": "1"
+      },
+      "deployments": [
+        {
+          "chainId": 84532,
+          "address": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Mandate",
+    "info": {
+      "url": "https://github.com/Satianurag/mandate"
+    }
+  },
+  "display": {
+    "formats": {
+      "Voucher(bytes32 channelId,uint128 maxClaimableAmount)": {
+        "intent": "Authorize a batch-settlement voucher",
+        "fields": [
+          { "path": "channelId", "label": "Channel", "format": "raw", "visible": "always" },
+          { "path": "maxClaimableAmount", "label": "Max claimable", "format": "raw", "visible": "always" }
+        ]
+      },
+      "Refund(bytes32 channelId,uint256 nonce,uint128 amount)": {
+        "intent": "Refund unspent mandate deposit",
+        "fields": [
+          { "path": "channelId", "label": "Channel", "format": "raw", "visible": "always" },
+          { "path": "nonce", "label": "Nonce", "format": "raw" },
+          { "path": "amount", "label": "Refund amount", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/mandate/testsv2/eip712-x402-BatchSettlement.tests.json
+++ b/registry/mandate/testsv2/eip712-x402-BatchSettlement.tests.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../eip712-x402-BatchSettlement.json",
+  "tests": [
+    {
+      "description": "batch-settlement voucher on Base Sepolia",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Voucher": [
+            { "name": "channelId", "type": "bytes32" },
+            { "name": "maxClaimableAmount", "type": "uint128" }
+          ]
+        },
+        "primaryType": "Voucher",
+        "domain": {
+          "name": "x402 Batch Settlement",
+          "version": "1",
+          "chainId": 84532,
+          "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+        },
+        "message": {
+          "channelId": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "maxClaimableAmount": "5000000"
+        }
+      },
+      "expected": {
+        "intent": "Authorize a batch-settlement voucher",
+        "owner": "Mandate",
+        "fields": [
+          { "label": "Channel", "value": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+          { "label": "Max claimable", "value": "5000000" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- ERC-7730 metadata for x402 batch-settlement EIP-712 (`Voucher`, `Refund`) on Base Sepolia (`84532`).
- `verifyingContract` is the deployed proxy `0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003` (code observed live). Domain name/version match `@x402/evm` (`x402 Batch Settlement` / `1`).
- MandateStepUp is **not** included: it has no on-chain verifier. Zero-address descriptors are banned.

## Test plan
- [ ] Registry CI schema + testsv2
- [ ] Maintainer review of labels
- [ ] Device ingest (until then, docs say pending registry — no fake Clear Signing)


Made with [Cursor](https://cursor.com)