### PR TITLE
ci: show the rendered fields and the declared format of each passing case in the results comment

### DIFF
--- a/.github/scripts/render-test-results.js
+++ b/.github/scripts/render-test-results.js
@@ -23,8 +23,7 @@
  * test file and the descriptor side by side.
  *
  * Every input can come from a fork, so every string that lands in the comment
- * goes through text(), cell() or block(). To preview the comment locally, see
- * .github/test-runner-docs/README.md.
+ * goes through text(), cell() or block().
  */
 
 const fs = require('fs');

--- a/.github/scripts/render-test-results.js
+++ b/.github/scripts/render-test-results.js
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * Renders the "Clear Signing Tests" comment that clear-signing-tests-results.yml
+ * writes on a pull request, from the artifacts of one clear-signing-tests.yml
+ * run: the pr-context artifact (context.json, the test files and the resolved
+ * descriptors), the results__* artifacts of the runners and, when given, the
+ * test-coverage artifact (coverage.json, the report of check-test-coverage).
+ *
+ * Usage: node render-test-results.js --context <pr-context dir> --artifacts <results dir> [--coverage <test-coverage dir>]
+ *
+ * The run itself comes from the environment, because a fork cannot change the
+ * workflow_run event: RUN_URL, TESTED_SHA, COMMIT_URL, RUN_STARTED_AT and
+ * RUN_COMPLETED_AT. Writes the comment body to stdout. An empty body means
+ * that the workflow must remove the comment, because no descriptor was
+ * affected.
+ *
+ * The comment holds a status table with one column per implementation, the
+ * expected and the rendered output of every case that did not pass, and, for
+ * every case that passed, the rendered fields next to the display format that
+ * the descriptor declares for the function, as it is. The runner names the
+ * descriptor file in `descriptor` and the function in the `format` key of the
+ * case. The last part lets a reviewer check a descriptor without reading the
+ * test file and the descriptor side by side.
+ *
+ * Every input can come from a fork, so every string that lands in the comment
+ * goes through text(), cell() or block(). To preview the comment locally, see
+ * .github/test-runner-docs/README.md.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { parseArgs } = require('util');
+
+// GitHub rejects a comment body above 65536 characters.
+const MAX_BODY = 60000;
+
+const STATUS_ICONS = { pass: '✅', fail: '❌', error: '⚠️', skipped: '⏭️' };
+const icon = (s) => (Object.hasOwn(STATUS_ICONS, s) ? STATUS_ICONS[s] : '—');
+
+/** Keeps an untrusted string on one line, with no markup of its own. */
+const text = (v, max = 200) =>
+  String(v ?? '')
+    .replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
+    .replace(/[\r\n]+/g, ' ')
+    .slice(0, max);
+
+/** Keeps an untrusted string inside one table cell. */
+const cell = (v) => text(v).replace(/\|/g, '\\|');
+
+/** Keeps an untrusted string inside one code span, outside a table. */
+const code = (v) => {
+  const t = text(v).replace(/`/g, '');
+  return t === '' ? '' : `\`${t}\``;
+};
+
+/** Keeps an untrusted value inside one fenced JSON block. */
+const block = (v) => {
+  const text_ = v != null ? JSON.stringify(v, null, 2) : '(none)';
+  return text_.length > 4000 ? `${text_.slice(0, 4000)}\n… truncated` : text_;
+};
+
+const utc = (value) =>
+  Number.isNaN(Date.parse(value))
+    ? 'an unknown time'
+    : `${new Date(value).toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+
+const warn = (message) => process.stderr.write(`warning: ${message}\n`);
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    warn(`could not read ${file}: ${e.message}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The descriptor side: the display format that a case exercised.
+// ---------------------------------------------------------------------------
+
+/** The rendered fields as label and value pairs. */
+function renderedFields(value) {
+  // The shape of the runner guide: an object keyed by label.
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.entries(value).map(([label, v]) => ({ label, value: v }));
+  }
+  if (Array.isArray(value)) return value.filter((f) => f && typeof f === 'object');
+  return [];
+}
+
+const isNested = (value) => value != null && typeof value === 'object' && 'fields' in value;
+
+/** The table rows of one rendered output, with nested calldata indented. */
+function fieldRows(rendered, depth = 0) {
+  const indent = depth === 0 ? '' : `${'&nbsp;&nbsp;'.repeat(depth)}↳ `;
+  const lines = [];
+  for (const field of renderedFields(rendered.fields)) {
+    const label = `${indent}${cell(field.label)}`;
+    if (isNested(field.value)) {
+      const inner = field.value;
+      const head = [inner.intent, inner.interpolatedIntent, inner.owner]
+        .filter((v) => v != null && v !== '')
+        .map(cell)
+        .join(' · ');
+      lines.push(`| ${label} | ${head} |`);
+      lines.push(...fieldRows(inner, depth + 1));
+    } else {
+      lines.push(`| ${label} | ${cell(field.value)} |`);
+    }
+  }
+  return lines;
+}
+
+/** One collapsed section for a case that passed. */
+function renderPassedCase(row, loadDescriptor, testCase, passedOn) {
+  const result = row.byImpl[passedOn[0]];
+  const rendered = result.rendered ?? testCase?.expected;
+  if (!rendered || typeof rendered !== 'object') return '';
+
+  // The runner reports the descriptor file and the key of display.formats
+  // that it matched.
+  const descriptor = loadDescriptor(result.descriptor);
+  const formats = descriptor?.display?.formats;
+  const format = typeof result.format === 'string' && formats && typeof formats === 'object' ? formats[result.format] : undefined;
+
+  let out = `<details>\n<summary>✅ ${text(row.entity)}/${text(row.descriptor)} · ${text(row.description)}</summary>\n\n`;
+
+  const meta = [];
+  if (result.format != null) meta.push(`**Format:** ${code(result.format)}`);
+  else meta.push('**Format:** not reported by the runner');
+  meta.push(`**Intent:** ${code(rendered.intent)}`);
+  if (rendered.interpolatedIntent != null) meta.push(`**Rendered intent:** ${code(rendered.interpolatedIntent)}`);
+  if (rendered.owner != null) meta.push(`**Owner:** ${code(rendered.owner)}`);
+  out += `${meta.join(' · ')}\n\n`;
+
+  out += '| Label | Rendered |\n| --- | --- |\n';
+  const lines = fieldRows(rendered);
+  out += lines.length > 0 ? `${lines.join('\n')}\n` : '| _(no field)_ | |\n';
+
+  // The format of the function as the descriptor declares it, with its
+  // includes resolved, so the reviewer sees the params of each field next to
+  // what it rendered as.
+  if (format) out += `\n**Declared format:**\n\n\`\`\`json\n${block(format)}\n\`\`\`\n`;
+  else if (result.descriptor == null) out += '\n_The runner reported no descriptor, so the declared format cannot be shown._\n';
+  else if (!descriptor) out += `\n_No descriptor ${code(result.descriptor)} in the pull request context._\n`;
+  else if (result.format != null) out += `\n_The descriptor declares no format ${code(result.format)}._\n`;
+
+  out += `\nPassed on ${passedOn.map(code).join(', ')}\n\n</details>\n`;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The comment.
+// ---------------------------------------------------------------------------
+
+function render({ contextRoot, artifactsRoot, coverageRoot, env }) {
+  const runUrl = env.RUN_URL ?? '';
+  const testedSha = env.TESTED_SHA ?? '';
+
+  // The artifact can be absent when the test run failed early. Say so,
+  // instead of leaving the "in progress" note on the pull request.
+  let ctx = null;
+  if (fs.existsSync(path.join(contextRoot, 'context.json'))) {
+    ctx = readJson(path.join(contextRoot, 'context.json'));
+  } else {
+    warn(`no pull request context in ${contextRoot}`);
+  }
+
+  let body = '## Clear Signing Tests\n\n';
+  body += `Tested [\`${cell(testedSha).slice(0, 7)}\`](${env.COMMIT_URL ?? ''})`;
+  body += ` · started ${utc(env.RUN_STARTED_AT)}`;
+  body += ` · finished ${utc(env.RUN_COMPLETED_AT)}\n\n`;
+
+  if (ctx === null) {
+    return `${body}> The test run produced no results. See the [run](${runUrl}).\n`;
+  }
+
+  // Nothing was affected, so there is nothing to report.
+  if (!ctx.has_affected) return '';
+
+  // require-testsv2 already failed the run, but the annotations do not
+  // explain how to fix it.
+  const missing = Array.isArray(ctx.missing_tests) ? ctx.missing_tests : [];
+  if (missing.length > 0) {
+    body += `❌ ${missing.length} affected descriptor(s) have no test file:\n\n`;
+    for (const descriptor of missing) body += `- \`${cell(descriptor)}\`\n`;
+    body +=
+      '\nCreate a test file at `registry/<entity>/testsv2/<descriptor-name>.tests.json`. ' +
+      'See [testing documentation](../blob/master/README.md#reference-test-cases) for details.\n\n';
+  }
+
+  // check-test-coverage already failed the run, like require-testsv2. The
+  // report is absent when the job did not run, or the run failed before it.
+  const coverageFile = coverageRoot ? path.join(coverageRoot, 'coverage.json') : null;
+  const coverage = coverageFile && fs.existsSync(coverageFile) ? readJson(coverageFile) : null;
+  const gaps = coverage && typeof coverage === 'object' ? Object.entries(coverage) : [];
+  if (gaps.length > 0) {
+    body += `❌ ${gaps.length} affected descriptor(s) failed the test coverage check:\n\n`;
+    for (const [descriptor, messages] of gaps) {
+      body += `- \`${cell(descriptor)}\`\n`;
+      for (const message of Array.isArray(messages) ? messages : []) body += `  - ${text(message, 1000)}\n`;
+    }
+    body += '\n';
+  }
+
+  // No descriptor had a test file, so no runner produced anything.
+  if (!ctx.has_tests) return body;
+
+  // Each artifact is a single file named `<slug>__<entity>__<descriptor>.json`.
+  // With merge-multiple: true they all land flat in artifactsRoot.
+  let resultFiles = [];
+  try {
+    // Grouped by descriptor, so that the rows of one descriptor sit together
+    // whatever the implementation that ran it.
+    const byDescriptor = (f) => f.replace(/\.json$/, '').split('__').slice(1).join('__');
+    resultFiles = fs
+      .readdirSync(artifactsRoot)
+      .filter((f) => f.endsWith('.json'))
+      .sort((a, b) => byDescriptor(a).localeCompare(byDescriptor(b)) || a.localeCompare(b));
+  } catch (e) {
+    warn(`could not read ${artifactsRoot}: ${e.message}`);
+  }
+  process.stderr.write(`Matched ${resultFiles.length} result JSON files\n`);
+
+  if (resultFiles.length === 0) {
+    return `${body}> No implementation test results were uploaded. See the [run](${runUrl}).\n`;
+  }
+
+  // The test files and the descriptors travel in the pr-context artifact, so
+  // both are available without a checkout of the head.
+  const cache = new Map();
+  const load = (file) => {
+    if (!cache.has(file)) cache.set(file, fs.existsSync(file) ? readJson(file) : null);
+    return cache.get(file);
+  };
+  const loadCase = (entity, descriptor, description) => {
+    const doc = load(path.join(contextRoot, 'tests', `${entity}__${descriptor}.tests.json`));
+    if (!doc || !Array.isArray(doc.tests)) return null;
+    return doc.tests.find((t) => t && t.description === description) ?? null;
+  };
+  // The runner names the descriptor by its path in the repository. Only that
+  // shape is followed, so the path cannot leave the descriptors directory.
+  const loadDescriptor = (descriptorPath) =>
+    typeof descriptorPath === 'string' && /^registry\/[\w.-]+\/[\w.-]+\.json$/.test(descriptorPath)
+      ? load(path.join(contextRoot, 'descriptors', descriptorPath))
+      : null;
+
+  // rows: keyed by entity|descriptor|description, each with a per-impl
+  // status, rendered output and message.
+  const rows = new Map();
+  const impls = new Set();
+  for (const file of resultFiles) {
+    const data = readJson(path.join(artifactsRoot, file));
+    if (!data) continue;
+    const impl = data.implementation || file;
+    impls.add(impl);
+    const parts = file.replace(/\.json$/, '').split('__');
+    const entity = parts[1];
+    const descriptor = parts[2];
+    for (const c of Array.isArray(data.cases) ? data.cases : []) {
+      if (!c || typeof c !== 'object') continue;
+      const key = `${entity}|${descriptor}|${c.description}`;
+      if (!rows.has(key)) rows.set(key, { entity, descriptor, description: c.description, byImpl: {} });
+      rows.get(key).byImpl[impl] = {
+        status: c.status,
+        rendered: c.rendered,
+        message: c.message,
+        descriptor: data.descriptor,
+        format: c.format,
+      };
+    }
+  }
+  const implList = [...impls].sort();
+
+  // --- Compact status table ---
+  const header = ['Entity', 'Descriptor', 'Case', ...implList.map(cell)].join(' | ');
+  const sep = ['---', '---', '---', ...implList.map(() => ':---:')].join(' | ');
+  body += `| ${header} |\n| ${sep} |\n`;
+  for (const r of rows.values()) {
+    const cells = implList.map((i) => icon((r.byImpl[i] || {}).status));
+    body += `| ${cell(r.entity)} | ${cell(r.descriptor)} | ${cell(r.description)} | ${cells.join(' | ')} |\n`;
+  }
+  body += '\n✅ pass · ❌ fail · ⚠️ error · ⏭️ skipped · — not run\n';
+
+  // --- Details for non-pass cases ---
+  const details = [];
+  for (const r of rows.values()) {
+    for (const impl of implList) {
+      const result = r.byImpl[impl];
+      if (!result || result.status === 'pass') continue;
+      // A summary is raw HTML, so a code span needs the tag, not backticks.
+      const summary = `${icon(result.status)} ${text(r.entity)}/${text(r.descriptor)} · ${text(r.description)} · <code>${text(impl)}</code>`;
+      let block_ = `<details>\n<summary>${summary}</summary>\n\n`;
+      if (result.message) block_ += `> ${text(result.message)}\n\n`;
+      if (result.status === 'fail') {
+        const expected = loadCase(r.entity, r.descriptor, r.description)?.expected ?? null;
+        block_ += `**Expected:**\n\n\`\`\`json\n${block(expected)}\n\`\`\`\n\n`;
+        block_ += `**Got:**\n\n\`\`\`json\n${block(result.rendered)}\n\`\`\`\n`;
+      }
+      block_ += '\n</details>\n';
+      details.push(block_);
+    }
+  }
+  if (details.length > 0) body += '\n### Details\n\n' + details.join('\n');
+
+  // --- Rendered fields of the cases that passed ---
+  // A case that passed rendered exactly the expected output, so one section
+  // per case is enough, whatever the number of implementations.
+  const passed = [];
+  for (const r of rows.values()) {
+    const passedOn = implList.filter((i) => r.byImpl[i]?.status === 'pass');
+    if (passedOn.length === 0) continue;
+    const section = renderPassedCase(r, loadDescriptor, loadCase(r.entity, r.descriptor, r.description), passedOn);
+    if (section !== '') passed.push(section);
+  }
+  if (passed.length > 0) {
+    body +=
+      '\n### Rendered fields\n\n' +
+      'The rendered fields of each case that passed, with the display format that the descriptor declares for it.\n\n';
+    // Add sections while the comment fits, and say how many did not.
+    const footer = `\n📋 [View test details](${runUrl})\n`;
+    const reserve = footer.length + 200;
+    let added = 0;
+    for (const section of passed) {
+      if (body.length + section.length + reserve > MAX_BODY) break;
+      body += `${section}\n`;
+      added++;
+    }
+    if (added < passed.length) {
+      body += `> ${passed.length - added} more case(s) are not shown, because the comment would exceed the size limit of GitHub. See the [run](${runUrl}).\n`;
+    }
+  }
+
+  body += `\n📋 [View test details](${runUrl})\n`;
+
+  if (body.length > MAX_BODY) {
+    body = `${body.slice(0, MAX_BODY)}\n\n… truncated. See the [run](${runUrl}).\n`;
+  }
+  return body;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: { context: { type: 'string' }, artifacts: { type: 'string' }, coverage: { type: 'string' } },
+  });
+  if (!values.context || !values.artifacts) {
+    process.stderr.write(
+      'Usage: node render-test-results.js --context <pr-context dir> --artifacts <results dir> [--coverage <test-coverage dir>]\n',
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    render({
+      contextRoot: path.resolve(values.context),
+      artifactsRoot: path.resolve(values.artifacts),
+      coverageRoot: values.coverage ? path.resolve(values.coverage) : null,
+      env: process.env,
+    }),
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { render };

--- a/.github/test-runner-docs/README.md
+++ b/.github/test-runner-docs/README.md
@@ -20,10 +20,12 @@ Write a single `results.json` per descriptor to the working directory.
 {
   "runner": "@ethereum-sourcify/clear-signing-test-runner",
   "implementation": "@ethereum-sourcify/clear-signing@0.1.1",
+  "descriptor": "registry/example/calldata-SmartAccount.json",
   "cases": [
     {
       "description": "Smart account execute: approve 100 USDC",
       "status": "pass",
+      "format": "execute(address target, uint256 value, bytes data)",
       "rendered": {
         "intent": "Execute call",
         "interpolatedIntent": "Execute call on USDC",
@@ -55,11 +57,13 @@ Write a single `results.json` per descriptor to the working directory.
 | --------------------- | ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `runner`              | yes         | string | Identifier of the test runner harness emitting this file. Always `@ethereum-sourcify/clear-signing-test-runner`                                                                                                                                             |
 | `implementation`      | yes         | string | Identifier of the clear-signing implementation under test, in `package@version` form                                                                                                                                                                        |
+| `descriptor`          | yes         | string | Path of the descriptor under test, relative to the repository root, e.g. `registry/aave/calldata-lpv3.json`. The pull request comment reads the descriptor from it                                                                                        |
 | `cases`               | yes         | array  | One entry per test case from the `.tests.json` input                                                                                                                                                                                                        |
 | `cases[].description` | yes         | string | Copied verbatim from the `description` field of the source test case — used to join back to the fixture. Fixtures must keep descriptions unique within a file; runners can rely on that to key results without collision                                    |
 | `cases[].status`      | yes         | enum   | One of `pass`, `fail`, `error`, `skipped` (see below)                                                                                                                                                                                                       |
 | `cases[].rendered`    | conditional | object | What the runner produced. Same shape as `expected` in the test data file — see [The `expected` block](../../README.md#the-expected-block) in the main README for the field-level breakdown. Required on `pass` and `fail`; omitted on `error` and `skipped` |
 | `cases[].message`     | optional    | string | Human-readable note. Required on `error` and `skipped`; optional on `fail`                                                                                                                                                                                  |
+| `cases[].format`      | conditional | string | The key of the descriptor's `display.formats` that the implementation matched for the case: the function signature of a calldata descriptor, or the primary type of an EIP-712 descriptor. Required on `pass` and `fail`; omitted on `error` and `skipped`. The pull request comment shows the declared format next to the rendered fields |
 
 **Calldata formatters.** Fields that use a calldata formatter (the field's value is itself an encoded inner call) appear as a nested `rendered`-shaped object in `fields`; nesting is recursive.
 
@@ -84,3 +88,19 @@ Write a single `results.json` per descriptor to the working directory.
 Wrap the runner in a composite action under `.github/actions/run-<name>-tests/` and add a sibling job in [`clear-signing-tests.yml`](../workflows/clear-signing-tests.yml). The action should call [`upload-test-results`](../actions/upload-test-results/action.yml) to publish the artifact.
 
 See [`run-sourcify-tests`](../actions/run-sourcify-tests/action.yml) for a complete reference implementation.
+
+## Previewing the pull request comment
+
+[`clear-signing-tests-results.yml`](../workflows/clear-signing-tests-results.yml) builds the comment with [`render-test-results.js`](../scripts/render-test-results.js) from two directories: the `pr-context` artifact (`context.json`, the test files as `tests/<entity>__<descriptor>.tests.json`, the descriptors with their includes resolved under `descriptors/`, at their repository path) and the flat `results__*` artifacts (`<slug>__<entity>__<descriptor>.json`), plus, with `--coverage`, the `test-coverage` artifact (`coverage.json`, the report of the `check-test-coverage` job). The same script runs locally, so a change to the comment can be checked without a pull request. From the repository root, with one descriptor as an example:
+
+```bash
+mkdir -p preview/pr-context/tests preview/pr-context/descriptors/registry/ekubo preview/artifacts
+cp registry/ekubo/testsv2/calldata-Positions.tests.json preview/pr-context/tests/ekubo__calldata-Positions.tests.json
+node .github/scripts/resolve-erc7730-includes.js registry/ekubo/calldata-Positions.json preview/pr-context/descriptors/registry/ekubo/calldata-Positions.json
+echo '{"has_affected": true, "has_tests": true, "missing_tests": []}' > preview/pr-context/context.json
+# Put a results.json from a runner at preview/artifacts/<slug>__ekubo__calldata-Positions.json, then:
+# Optionally, node .github/scripts/check-selector-coverage.js --report preview/test-coverage/coverage.json registry/ekubo/calldata-Positions.json
+RUN_URL=https://example.test/run TESTED_SHA=0000000 node .github/scripts/render-test-results.js --context preview/pr-context --artifacts preview/artifacts --coverage preview/test-coverage > preview/results.md
+```
+
+`jq -n --rawfile t preview/results.md '{text: $t, mode: "gfm"}' | gh api -X POST /markdown --input - > preview/results.html` renders the body the way GitHub does.

--- a/.github/test-runner-docs/README.md
+++ b/.github/test-runner-docs/README.md
@@ -88,19 +88,3 @@ Write a single `results.json` per descriptor to the working directory.
 Wrap the runner in a composite action under `.github/actions/run-<name>-tests/` and add a sibling job in [`clear-signing-tests.yml`](../workflows/clear-signing-tests.yml). The action should call [`upload-test-results`](../actions/upload-test-results/action.yml) to publish the artifact.
 
 See [`run-sourcify-tests`](../actions/run-sourcify-tests/action.yml) for a complete reference implementation.
-
-## Previewing the pull request comment
-
-[`clear-signing-tests-results.yml`](../workflows/clear-signing-tests-results.yml) builds the comment with [`render-test-results.js`](../scripts/render-test-results.js) from two directories: the `pr-context` artifact (`context.json`, the test files as `tests/<entity>__<descriptor>.tests.json`, the descriptors with their includes resolved under `descriptors/`, at their repository path) and the flat `results__*` artifacts (`<slug>__<entity>__<descriptor>.json`), plus, with `--coverage`, the `test-coverage` artifact (`coverage.json`, the report of the `check-test-coverage` job). The same script runs locally, so a change to the comment can be checked without a pull request. From the repository root, with one descriptor as an example:
-
-```bash
-mkdir -p preview/pr-context/tests preview/pr-context/descriptors/registry/ekubo preview/artifacts
-cp registry/ekubo/testsv2/calldata-Positions.tests.json preview/pr-context/tests/ekubo__calldata-Positions.tests.json
-node .github/scripts/resolve-erc7730-includes.js registry/ekubo/calldata-Positions.json preview/pr-context/descriptors/registry/ekubo/calldata-Positions.json
-echo '{"has_affected": true, "has_tests": true, "missing_tests": []}' > preview/pr-context/context.json
-# Put a results.json from a runner at preview/artifacts/<slug>__ekubo__calldata-Positions.json, then:
-# Optionally, node .github/scripts/check-selector-coverage.js --report preview/test-coverage/coverage.json registry/ekubo/calldata-Positions.json
-RUN_URL=https://example.test/run TESTED_SHA=0000000 node .github/scripts/render-test-results.js --context preview/pr-context --artifacts preview/artifacts --coverage preview/test-coverage > preview/results.md
-```
-
-`jq -n --rawfile t preview/results.md '{text: $t, mode: "gfm"}' | gh api -X POST /markdown --input - > preview/results.html` renders the body the way GitHub does.

--- a/.github/test-runner-docs/fail.example.json
+++ b/.github/test-runner-docs/fail.example.json
@@ -1,10 +1,12 @@
 {
   "runner": "@ethereum-sourcify/clear-signing-test-runner",
   "implementation": "@ethereum-sourcify/clear-signing@0.1.1",
+  "descriptor": "registry/aave/calldata-lpv3.json",
   "cases": [
     {
       "description": "Manage collateral — disable WETH",
       "status": "fail",
+      "format": "setUserUseReserveAsCollateral(address asset, bool useAsCollateral)",
       "rendered": {
         "intent": "Manage collateral",
         "owner": "Aave DAO",

--- a/.github/test-runner-docs/pass.example.json
+++ b/.github/test-runner-docs/pass.example.json
@@ -1,10 +1,12 @@
 {
   "runner": "@ethereum-sourcify/clear-signing-test-runner",
   "implementation": "@ethereum-sourcify/clear-signing@0.1.1",
+  "descriptor": "registry/example/calldata-SmartAccount.json",
   "cases": [
     {
       "description": "Smart account execute: approve 100 USDC",
       "status": "pass",
+      "format": "execute(address target, uint256 value, bytes data)",
       "rendered": {
         "intent": "Execute call",
         "interpolatedIntent": "Execute call on USDC",

--- a/.github/workflows/clear-signing-tests-results.yml
+++ b/.github/workflows/clear-signing-tests-results.yml
@@ -34,6 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # The rendering script comes from the default branch, because a
+      # workflow_run event runs there. A fork cannot change it.
+      - name: Checkout the scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Download the pull request context
         id: context
         continue-on-error: true
@@ -63,29 +71,32 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Render the results comment
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}
+          RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+          RUN_COMPLETED_AT: ${{ github.event.workflow_run.updated_at }}
+        # The commit under test, and the start and end time of the run, come
+        # from the workflow_run event, not from the artifact, so a fork cannot
+        # change them. A reviewer can therefore see if the results belong to
+        # the head of the pull request or to an older commit.
+        run: node .github/scripts/render-test-results.js --context pr-context --artifacts artifacts --coverage test-coverage > results.md
+
       - name: Post PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
           RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
-          RUN_COMPLETED_AT: ${{ github.event.workflow_run.updated_at }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
 
-            const STATUS_ICONS = { pass: '✅', fail: '❌', error: '⚠️', skipped: '⏭️' };
-            const icon = (s) => (Object.hasOwn(STATUS_ICONS, s) ? STATUS_ICONS[s] : '—');
-            // GitHub rejects a comment body above 65536 characters.
-            const MAX_BODY = 60000;
             const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${process.env.RUN_ID}`;
             const workspace = process.env.GITHUB_WORKSPACE;
-            const artifactsRoot = path.join(workspace, 'artifacts');
-            const contextRoot = path.join(workspace, 'pr-context');
 
             // A fork wrote the artifact, so the pull request must come from
             // the event, which a fork cannot change.
@@ -102,51 +113,6 @@ jobs:
               return;
             }
             const issue_number = pr.number;
-
-            // The artifact can be absent when the test run failed early. Say so,
-            // instead of leaving the "in progress" note on the pull request.
-            let ctx;
-            try {
-              ctx = JSON.parse(fs.readFileSync(path.join(contextRoot, 'context.json'), 'utf8'));
-            } catch (e) {
-              core.warning(`No usable pull request context: ${e.message}`);
-              ctx = null;
-            }
-
-            // Runner strings are untrusted. Keep them inside one line.
-            const line = (v) =>
-              String(v ?? '')
-                .replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
-                .replace(/\|/g, '\\|')
-                .replace(/[\r\n]+/g, ' ');
-            // And inside one table cell.
-            const cell = (v) => line(v).slice(0, 200);
-            const block = (v) => {
-              const text = v != null ? JSON.stringify(v, null, 2) : '(none)';
-              return text.length > 4000 ? `${text.slice(0, 4000)}\n… truncated` : text;
-            };
-
-            // Each artifact is a single file named
-            // `<slug>__<entity>__<descriptor>.json`. With merge-multiple: true
-            // they all land flat in artifactsRoot, with no collisions.
-            let resultFiles = [];
-            try {
-              resultFiles = fs.readdirSync(artifactsRoot).filter(f => f.endsWith('.json'));
-            } catch (e) {
-              core.warning(`Could not read ${artifactsRoot}: ${e.message}`);
-            }
-            core.info(`Matched ${resultFiles.length} result JSON files`);
-
-            // The commit under test, and the start and end time of the run.
-            // All three come from the workflow_run event, not from the
-            // artifact, so a fork cannot change them. A reviewer can therefore
-            // see if the results belong to the head of the pull request or to
-            // an older commit.
-            const testedSha = process.env.RUN_HEAD_SHA;
-            const utc = (value) =>
-              Number.isNaN(Date.parse(value))
-                ? 'an unknown time'
-                : `${new Date(value).toISOString().slice(0, 16).replace('T', ' ')} UTC`;
 
             // Writes, replaces or removes one comment. An empty text removes it.
             const RESULTS = '## Clear Signing Tests';
@@ -170,158 +136,15 @@ jobs:
             };
 
             // A separate comment, and not part of the results, because it never
-            // blocks the pull request. It is written before the branches below,
-            // which return early.
+            // blocks the pull request.
             let recommendations = '';
             try {
-              recommendations = fs.readFileSync(path.join(contextRoot, 'recommendations.md'), 'utf8').trim();
+              recommendations = fs.readFileSync(path.join(workspace, 'pr-context', 'recommendations.md'), 'utf8').trim();
             } catch {
               // The test run failed before it could collect them.
             }
             await upsert(recommendations, RECOMMENDATIONS);
 
-            let body = '## Clear Signing Tests\n\n';
-            body += `Tested [\`${testedSha.slice(0, 7)}\`](${context.serverUrl}/${owner}/${repo}/commit/${testedSha})`;
-            body += ` · started ${utc(process.env.RUN_STARTED_AT)}`;
-            body += ` · finished ${utc(process.env.RUN_COMPLETED_AT)}\n\n`;
-
-            // The test run failed before it could describe itself.
-            if (ctx === null) {
-              body += `> The test run produced no results. See the [run](${runUrl}).\n`;
-              await upsert(body);
-              return;
-            }
-
-            // Nothing was affected, so there is nothing to report.
-            if (!ctx.has_affected) {
-              await upsert('');
-              return;
-            }
-
-            // require-testsv2 already failed the run, but the annotations do
-            // not explain how to fix it.
-            const missing = ctx.missing_tests ?? [];
-            if (missing.length > 0) {
-              body += `❌ ${missing.length} affected descriptor(s) have no test file:\n\n`;
-              for (const descriptor of missing) body += `- \`${cell(descriptor)}\`\n`;
-              body +=
-                '\nCreate a test file at `registry/<entity>/testsv2/<descriptor-name>.tests.json`. ' +
-                'See [testing documentation](../blob/master/README.md#reference-test-cases) for details.\n\n';
-            }
-
-            // check-test-coverage already failed the run, like require-testsv2.
-            let coverage = {};
-            try {
-              coverage = JSON.parse(fs.readFileSync(path.join(workspace, 'test-coverage', 'coverage.json'), 'utf8'));
-            } catch {
-              // The job did not run, or the run failed before it.
-            }
-            const gaps = Object.entries(coverage);
-            if (gaps.length > 0) {
-              body += `❌ ${gaps.length} affected descriptor(s) failed the test coverage check:\n\n`;
-              for (const [descriptor, messages] of gaps) {
-                body += `- \`${cell(descriptor)}\`\n`;
-                for (const message of messages) body += `  - ${line(message).slice(0, 1000)}\n`;
-              }
-              body += '\n';
-            }
-
-            // No descriptor had a test file, so no runner produced anything.
-            if (!ctx.has_tests) {
-              await upsert(body);
-              return;
-            }
-
-            if (resultFiles.length === 0) {
-              body += `> No implementation test results were uploaded. See the [run](${runUrl}).\n`;
-            } else {
-              // rows: keyed by entity|descriptor|description
-              // each row stores per-impl status + rendered (for diff blocks) + message
-              const rows = new Map();
-              const impls = new Set();
-
-              // The test files travel in the pr-context artifact, so the
-              // expected output is available without a checkout of the head.
-              const testFileCache = new Map();
-              const loadExpected = (entity, descriptor, description) => {
-                const key = `${entity}__${descriptor}`;
-                if (!testFileCache.has(key)) {
-                  const testPath = path.join(contextRoot, 'tests', `${key}.tests.json`);
-                  try {
-                    testFileCache.set(key, JSON.parse(fs.readFileSync(testPath, 'utf8')));
-                  } catch (e) {
-                    core.warning(`Could not read ${testPath}: ${e.message}`);
-                    testFileCache.set(key, null);
-                  }
-                }
-                const doc = testFileCache.get(key);
-                if (!doc || !Array.isArray(doc.tests)) return null;
-                const t = doc.tests.find(t => t.description === description);
-                return t ? t.expected : null;
-              };
-
-              for (const file of resultFiles) {
-                let data;
-                try { data = JSON.parse(fs.readFileSync(path.join(artifactsRoot, file), 'utf8')); }
-                catch (e) { core.warning(`Could not parse ${file}: ${e.message}`); continue; }
-                const impl = data.implementation || file;
-                impls.add(impl);
-                // filename: <slug>__<entity>__<descriptor>.json
-                const parts = file.replace(/\.json$/, '').split('__');
-                const entity = parts[1];
-                const descriptor = parts[2];
-                for (const c of data.cases || []) {
-                  const key = `${entity}|${descriptor}|${c.description}`;
-                  if (!rows.has(key)) rows.set(key, { entity, descriptor, description: c.description, byImpl: {} });
-                  rows.get(key).byImpl[impl] = {
-                    status: c.status,
-                    rendered: c.rendered,
-                    message: c.message,
-                  };
-                }
-              }
-
-              const implList = [...impls].sort();
-
-              // --- Compact status table ---
-              const header = ['Entity', 'Descriptor', 'Case', ...implList.map(cell)].join(' | ');
-              const sep = ['---', '---', '---', ...implList.map(() => ':---:')].join(' | ');
-              body += `| ${header} |\n| ${sep} |\n`;
-              for (const r of rows.values()) {
-                const cells = implList.map(i => icon((r.byImpl[i] || {}).status));
-                body += `| ${cell(r.entity)} | ${cell(r.descriptor)} | ${cell(r.description)} | ${cells.join(' | ')} |\n`;
-              }
-              body += '\n✅ pass · ❌ fail · ⚠️ error · ⏭️ skipped · — not run\n';
-
-              // --- Details for non-pass cases ---
-              const details = [];
-              for (const r of rows.values()) {
-                for (const impl of implList) {
-                  const result = r.byImpl[impl];
-                  if (!result || result.status === 'pass') continue;
-                  const summary = `${icon(result.status)} ${cell(r.entity)}/${cell(r.descriptor)} · ${cell(r.description)} · \`${cell(impl)}\``;
-                  let block_ = `<details>\n<summary>${summary}</summary>\n\n`;
-                  if (result.message) {
-                    block_ += `> ${cell(result.message)}\n\n`;
-                  }
-                  if (result.status === 'fail') {
-                    const expected = loadExpected(r.entity, r.descriptor, r.description);
-                    block_ += `**Expected:**\n\n\`\`\`json\n${block(expected)}\n\`\`\`\n\n`;
-                    block_ += `**Got:**\n\n\`\`\`json\n${block(result.rendered)}\n\`\`\`\n`;
-                  }
-                  block_ += '\n</details>\n';
-                  details.push(block_);
-                }
-              }
-              if (details.length > 0) {
-                body += '\n### Details\n\n' + details.join('\n');
-              }
-
-              body += `\n📋 [View test details](${runUrl})\n`;
-            }
-
-            if (body.length > MAX_BODY) {
-              body = `${body.slice(0, MAX_BODY)}\n\n… truncated. See the [run](${runUrl}).\n`;
-            }
-
-            await upsert(body);
+            // The results, rendered by the step above. An empty file means
+            // that the run affected no descriptor, so the comment goes away.
+            await upsert(fs.readFileSync(path.join(workspace, 'results.md'), 'utf8'));

--- a/.github/workflows/clear-signing-tests.yml
+++ b/.github/workflows/clear-signing-tests.yml
@@ -254,8 +254,8 @@ jobs:
 
       # clear-signing-tests-results.yml runs after this workflow and posts the
       # comment that a fork run cannot write. It learns the pull request and the
-      # tested descriptors from here, and it gets a copy of each test file, so
-      # it never has to check out the head of a fork.
+      # tested descriptors from here, and it gets a copy of each test file and
+      # of each descriptor, so it never has to check out the head of a fork.
       - name: Build the pull request context
         if: always()
         env:
@@ -272,7 +272,7 @@ jobs:
           TEST_MATRIX="${TEST_MATRIX:-[]}"
           MISSING_TESTS="${MISSING_TESTS:-[]}"
 
-          mkdir -p pr-context/tests
+          mkdir -p pr-context/tests pr-context/descriptors
           jq -n \
             --argjson pr_number "$PR_NUMBER" \
             --arg head_sha "$HEAD_SHA" \
@@ -287,9 +287,18 @@ jobs:
               matrix: $matrix, missing_tests: $missing}' \
             > pr-context/context.json
 
-          echo "$TEST_MATRIX" | jq -r '.[] | "\(.entity)\t\(.descriptor_name)\t\(.test_file)"' |
-            while IFS=$'\t' read -r entity descriptor test_file; do
+          echo "$TEST_MATRIX" | jq -r '.[] | "\(.entity)\t\(.descriptor_name)\t\(.test_file)\t\(.descriptor)"' |
+            while IFS=$'\t' read -r entity descriptor test_file descriptor_file; do
               cp "$test_file" "pr-context/tests/${entity}__${descriptor}.tests.json"
+              # The comment shows the format that the descriptor declares for
+              # each case, so it needs the descriptor with its includes
+              # resolved, under the path that the runner reports in its
+              # results. One that does not resolve is copied as it is; the
+              # schema check reports the cause.
+              mkdir -p "pr-context/descriptors/$(dirname "$descriptor_file")"
+              node base-scripts/.github/scripts/resolve-erc7730-includes.js \
+                "$descriptor_file" "pr-context/descriptors/$descriptor_file" ||
+                cp "$descriptor_file" "pr-context/descriptors/$descriptor_file"
             done
 
           cat pr-context/context.json


### PR DESCRIPTION
Closes #2966.

## What changes

The Clear Signing Tests comment is now built by `.github/scripts/render-test-results.js` from the `pr-context` artifact, the runner artifacts and the test coverage report added in #2965, instead of inline in `clear-signing-tests-results.yml`. The github-script step only finds the pull request and upserts the comment. The script is checked out from the default branch, so a fork cannot change it.

For every case that passed, the comment adds a collapsed **Rendered fields** section: the rendered label and value of each field, nested calldata indented under its parent, followed by the display format of the function exactly as the descriptor declares it, with includes resolved and `$ref` left as they are. A reviewer checks a descriptor without opening the test file and the descriptor side by side. The status table, the Expected/Got blocks of failing cases, the missing-test block and the coverage block are unchanged.

## results.json

Two keys are added to the runner output, documented in `.github/test-runner-docs/README.md` and both examples:

- `descriptor`: the path of the descriptor under test, relative to the repository root.
- `cases[].format`: the `display.formats` key the implementation matched, the function signature or the EIP-712 primary type. Required on `pass` and `fail`, like `rendered`.

The renderer looks both up directly. It only follows descriptor paths of the shape `registry/<entity>/<name>.json`, so a runner cannot point outside the pull request context. Until the runners emit the keys, the section says that the runner did not report them; everything else in the comment keeps working from the artifact file name.

The pull request context now carries each affected descriptor with its includes resolved, stored under its repository path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
