### PR TITLE
Add Livepeer BondingManager calldata descriptor

### DIFF
--- a/registry/livepeer/calldata-BondingManager.json
+++ b/registry/livepeer/calldata-BondingManager.json
@@ -184,7 +184,8 @@
             "path": "#._unbondingLockId",
             "visible": "always"
           }
-        ]
+        ],
+        "interpolatedIntent": "Withdraw #{_unbondingLockId}"
       },
       "bondWithHint(uint256 _amount, address _to, address _oldDelegateNewPosPrev, address _oldDelegateNewPosNext, address _currDelegateNewPosPrev, address _currDelegateNewPosNext)": {
         "intent": "Delegate LPT",

--- a/registry/livepeer/calldata-BondingManager.json
+++ b/registry/livepeer/calldata-BondingManager.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "BondingManager",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0x35Bcf3c30594191d53231E4FF333E8A770453e40"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Livepeer",
+    "info": {
+      "url": "https://livepeer.org"
+    },
+    "constants": {
+      "LPTaddress": "0x289ba1701C2F088cf0faf8B3705246331cB8A839"
+    },
+    "contractName": "BondingManager"
+  },
+  "display": {
+    "formats": {
+      "setRewardCaller(address _rewardCaller)": {
+        "intent": "Set or revoke reward caller",
+        "interpolatedIntent": "Reward caller {_rewardCaller}",
+        "fields": [
+          {
+            "label": "Reward caller",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            },
+            "path": "#._rewardCaller",
+            "visible": "always"
+          }
+        ]
+      },
+      "reward()": {
+        "intent": "Call reward",
+        "fields": []
+      },
+      "rewardWithHint(address _newPosPrev, address _newPosNext)": {
+        "intent": "Call reward",
+        "fields": [
+          {
+            "label": "List hint (prev)",
+            "path": "#._newPosPrev",
+            "visible": "never"
+          },
+          {
+            "label": "List hint (next)",
+            "path": "#._newPosNext",
+            "visible": "never"
+          }
+        ]
+      },
+      "rewardForTranscoder(address _transcoder)": {
+        "intent": "Call reward for orchestrator",
+        "interpolatedIntent": "Reward for {_transcoder}",
+        "fields": [
+          {
+            "label": "Orchestrator",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            },
+            "path": "#._transcoder",
+            "visible": "always"
+          }
+        ]
+      },
+      "rewardForTranscoderWithHint(address _transcoder, address _newPosPrev, address _newPosNext)": {
+        "intent": "Call reward for orchestrator",
+        "interpolatedIntent": "Reward for {_transcoder}",
+        "fields": [
+          {
+            "label": "Orchestrator",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            },
+            "path": "#._transcoder",
+            "visible": "always"
+          },
+          {
+            "label": "List hint (prev)",
+            "path": "#._newPosPrev",
+            "visible": "never"
+          },
+          {
+            "label": "List hint (next)",
+            "path": "#._newPosNext",
+            "visible": "never"
+          }
+        ]
+      },
+      "unbondWithHint(uint256 _amount, address _newPosPrev, address _newPosNext)": {
+        "intent": "Undelegate LPT",
+        "interpolatedIntent": "Undelegate {_amount}",
+        "fields": [
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": {
+              "token": "$.metadata.constants.LPTaddress"
+            },
+            "path": "#._amount",
+            "visible": "always"
+          },
+          {
+            "label": "List hint (prev)",
+            "path": "#._newPosPrev",
+            "visible": "never"
+          },
+          {
+            "label": "List hint (next)",
+            "path": "#._newPosNext",
+            "visible": "never"
+          }
+        ]
+      },
+      "withdrawFees(address _recipient, uint256 _amount)": {
+        "intent": "Withdraw fees",
+        "interpolatedIntent": "Withdraw {_amount}",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            },
+            "path": "#._recipient",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "amount",
+            "path": "#._amount",
+            "visible": "always"
+          }
+        ]
+      },
+      "withdrawStake(uint256 _unbondingLockId)": {
+        "intent": "Withdraw undelegated LPT",
+        "fields": [
+          {
+            "label": "Unbonding lock",
+            "format": "raw",
+            "path": "#._unbondingLockId",
+            "visible": "always"
+          }
+        ]
+      },
+      "bondWithHint(uint256 _amount, address _to, address _oldDelegateNewPosPrev, address _oldDelegateNewPosNext, address _currDelegateNewPosPrev, address _currDelegateNewPosNext)": {
+        "intent": "Delegate LPT",
+        "interpolatedIntent": "Delegate {_amount} to {_to}",
+        "fields": [
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": {
+              "token": "$.metadata.constants.LPTaddress"
+            },
+            "path": "#._amount",
+            "visible": "always"
+          },
+          {
+            "label": "Delegate",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            },
+            "path": "#._to",
+            "visible": "always"
+          },
+          {
+            "label": "List hint 1",
+            "path": "#._oldDelegateNewPosPrev",
+            "visible": "never"
+          },
+          {
+            "label": "List hint 2",
+            "path": "#._oldDelegateNewPosNext",
+            "visible": "never"
+          },
+          {
+            "label": "List hint 3",
+            "path": "#._currDelegateNewPosPrev",
+            "visible": "never"
+          },
+          {
+            "label": "List hint 4",
+            "path": "#._currDelegateNewPosNext",
+            "visible": "never"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/livepeer/testsv2/calldata-BondingManager.tests.json
+++ b/registry/livepeer/testsv2/calldata-BondingManager.tests.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-BondingManager.json",
+  "dataProvider": {
+    "tokens": {
+      "0x289ba1701c2f088cf0faf8b3705246331cb8a839": {
+        "symbol": "LPT",
+        "decimals": 18,
+        "name": "Livepeer Token"
+      }
+    }
+  },
+  "tests": [
+    {
+      "description": "Set reward caller - chain 42161",
+      "rawTx": "0x02f88e82a4b18201dd808402625a0082af5a9435bcf3c30594191d53231e4ff333e8a770453e4080a40103e60e0000000000000000000000001b0c26fc2e310efb2649c24ec9aa966effda292fc080a0f9ed597a227735c4d61effeaf1a4f770c1d27d70f469907d4911658bdf1132cda07ee3ff8244684c45c09bc40fea8cdf625633f9f5efb09f869e3ba16690d17dc9",
+      "txHash": "0x282653448fcd55b72801163fbdd9bebffda5f9325351eff560c58cf509847fa7",
+      "expected": {
+        "intent": "Set or revoke reward caller",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Reward caller",
+            "value": "0x1B0c26FC2E310eFB2649C24eC9AA966efFDA292F"
+          }
+        ],
+        "interpolatedIntent": "Reward caller 0x1B0c26FC2E310eFB2649C24eC9AA966efFDA292F"
+      }
+    },
+    {
+      "description": "Unset reward caller - chain 42161",
+      "rawTx": "0x02f88e82a4b18201da80840264f9e082ae269435bcf3c30594191d53231e4ff333e8a770453e4080a40103e60e0000000000000000000000000000000000000000000000000000000000000000c080a0df56d2410262b1546623726aabbaff2840d269e20733d6202f14fef8a8dafe6ea0258cd2f3f78c048ed9ccf2786c4fa28564ab36d0db9d491f4294feb588f7f5e0",
+      "txHash": "0xf69a9762f66e413debe2edb2f44fc9705f56cd2220590a95ccde80e873db9362",
+      "expected": {
+        "intent": "Set or revoke reward caller",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Reward caller",
+            "value": "0x0000000000000000000000000000000000000000"
+          }
+        ],
+        "interpolatedIntent": "Reward caller 0x0000000000000000000000000000000000000000"
+      }
+    },
+    {
+      "description": "Call reward - chain 42161",
+      "rawTx": "0x02f87382a4b182539a840bebc2008411e1a300830da5879435bcf3c30594191d53231e4ff333e8a770453e408084228cb733c001a082342f045178d7b09af974b951dfb97db1ed5f1f6287816ac11406589e1dd31da048740c964a8b4e560fc9e149567bf98fa1304dec5a0bd062d99a3bd05f77e30e",
+      "txHash": "0x49cfc4873d656b802892946ad11bdbc1bd9854d33aab96f010c265786ee47670",
+      "expected": {
+        "intent": "Call reward",
+        "owner": "Livepeer",
+        "fields": []
+      }
+    },
+    {
+      "description": "Call reward with list hints - chain 42161",
+      "rawTx": "0x02f8b082a4b18201db8084026586808307879f9435bcf3c30594191d53231e4ff333e8a770453e4080b84481871056000000000000000000000000980998e39d29dc5a92e7403fc9cd47e68b63ad5f00000000000000000000000041239fb65360981316fcb4a8548320d305f9496dc001a0db16272fb35eeddabdb27b3cf86b8b4c5c861e14988cb6a180b919e836164dd4a04fe38a616c47fca049943bd55c38a8648d9e73091f253419bc06323ba3f62921",
+      "txHash": "0x6e2d369084002188c52a1a7db46df247e261e5aaa8aac684afef5d1851554bbb",
+      "expected": {
+        "intent": "Call reward",
+        "owner": "Livepeer",
+        "fields": []
+      }
+    },
+    {
+      "description": "Call reward for orchestrator - chain 42161",
+      "rawTx": "0x02f88f82a4b18203c18084026e6fc0830ba4039435bcf3c30594191d53231e4ff333e8a770453e4080a41a8c41f80000000000000000000000005bdeedca9c6346b0ce6b17ffa8227a4dace37039c080a0f960cb70866970f5f58a8c53984573eaf547073837cd5057f85032fb42606493a07a6287be97e2fdebe547207f0fe780e4fbc7b305a58d5d0f0e4165bbbdf11502",
+      "txHash": "0x61d54ae95e7afb605f214297372194f5038818907ec22614be24cc2b75d84d04",
+      "expected": {
+        "intent": "Call reward for orchestrator",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Orchestrator",
+            "value": "0x5BdEedCA9c6346B0CE6b17ffa8227A4DACE37039"
+          }
+        ],
+        "interpolatedIntent": "Reward for 0x5BdEedCA9c6346B0CE6b17ffa8227A4DACE37039"
+      }
+    },
+    {
+      "description": "Call reward for orchestrator with list hints - chain 42161",
+      "rawTx": "0x02f8d082a4b18203c48084026288e0830793219435bcf3c30594191d53231e4ff333e8a770453e4080b864b556966a00000000000000000000000016a72bdb3017196825bc53809b87f96fbee31f6c000000000000000000000000980998e39d29dc5a92e7403fc9cd47e68b63ad5f00000000000000000000000041239fb65360981316fcb4a8548320d305f9496dc001a0484b13bab9c098511c35a6ef6dbd309c6a6745753501cc8297a3f61a6d2fbcb8a006443711c4d6c14b69516b6049409f25f2e01ece1b4d8025e809b90d1e3c4308",
+      "txHash": "0x67400dc9ed99f976d9f46c79010240a6164250a72d64bd593b214af64854933c",
+      "expected": {
+        "intent": "Call reward for orchestrator",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Orchestrator",
+            "value": "0x16a72bdb3017196825BC53809b87F96fbEE31F6C"
+          }
+        ],
+        "interpolatedIntent": "Reward for 0x16a72bdb3017196825BC53809b87F96fbEE31F6C"
+      }
+    },
+    {
+      "description": "Undelegate LPT with list hints - chain 42161",
+      "rawTx": "0x02f8d082a4b18207ef8084026269a0830484c89435bcf3c30594191d53231e4ff333e8a770453e4080b8649500ed9b000000000000000000000000000000000000000000000014ad927bcf60389690000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e0000000000000000000000004f4758f7167b18e1f5b3c1a7575e3eb584894dbcc001a03d37bfd85412dacb84adc8f99f3a31a558b775334e823246d59f41fa3900a2c5a06fa6d5ddb4c46b90a736380a6351a170ab8fe612d37a057166809dcc28d9df0b",
+      "txHash": "0xaf13f7db2a98702692c01738283ab426f4d08e6dca01ce806138f51bd1d3a911",
+      "expected": {
+        "intent": "Undelegate LPT",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Amount",
+            "value": "381.44207671995508904 LPT"
+          }
+        ],
+        "interpolatedIntent": "Undelegate 381.44207671995508904 LPT"
+      }
+    },
+    {
+      "description": "Withdraw fees - chain 42161",
+      "rawTx": "0x02f8b482a4b1820e36843b9aca0084773594008303c1269435bcf3c30594191d53231e4ff333e8a770453e4080b844ad3b1b47000000000000000000000000dc28f2842810d1a013ad51de174d02eaba192dc7000000000000000000000000000000000000000000000000011696613c228b4dc001a08902193a0c468bed06660415ad0d8a5c02e8e000aa4596af077b1e2e67050deea017d68d492860d382fd4f947d75562510c88d756ed76533b121ad771776d34e24",
+      "txHash": "0xfe754eaef01ef36f022847677c94ed8a1cc87b3fc8f580c5e03d38dd0fb56dea",
+      "expected": {
+        "intent": "Withdraw fees",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Recipient",
+            "value": "0xdc28F2842810D1a013aD51DE174D02eABA192dC7"
+          },
+          {
+            "label": "Amount",
+            "value": "0.078415387890453325 ETH"
+          }
+        ],
+        "interpolatedIntent": "Withdraw 0.078415387890453325 ETH"
+      }
+    },
+    {
+      "description": "Withdraw undelegated LPT - chain 42161",
+      "rawTx": "0x02f88f82a4b18207ee80840265f3e08301c2f79435bcf3c30594191d53231e4ff333e8a770453e4080a425d5971f00000000000000000000000000000000000000000000000000000000000001b4c080a0aca3f7ec06c79e170c252a5939b28c65014c0109b8621a30242904fda14d5b0da033a538adfa0b9418990bfc058b2fdf0f2626d802a1006130266ea8f7e01c9898",
+      "txHash": "0x4ef2ba563ac2aaff4118f8f67f22c72664b5ff7a8550a381b35e4abb18bdf822",
+      "expected": {
+        "intent": "Withdraw undelegated LPT",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Unbonding lock",
+            "value": "436"
+          }
+        ]
+      }
+    },
+    {
+      "description": "Delegate LPT with list hints - chain 42161",
+      "rawTx": "0x02f9013282a4b10184016f7e2084016f7e20830931ad9435bcf3c30594191d53231e4ff333e8a770453e4080b8c46bd9add4000000000000000000000000000000000000000000000004192927743b880000000000000000000000000000bc144f1a34f5b858900413d35bfb7cb6b3b0d65b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e0000000000000000000000000000000000000000000000000000000000000000c080a02205c63ad3cf4254856c9a572f129a99ba9a8bd289d94520d004b4f780cff8e7a07008c9ebb600a331218494179698eff9a5ec27e6fd046dc6e441fc3db4a54894",
+      "txHash": "0x869dc30114d5760a6c33fa470b19c4fb2fbfc27b9eed44f5b9aa418b9910f962",
+      "expected": {
+        "intent": "Delegate LPT",
+        "owner": "Livepeer",
+        "fields": [
+          {
+            "label": "Amount",
+            "value": "75.6 LPT"
+          },
+          {
+            "label": "Delegate",
+            "value": "0xbc144F1a34f5b858900413D35BFb7cb6b3B0d65b"
+          }
+        ],
+        "interpolatedIntent": "Delegate 75.6 LPT to 0xbc144F1a34f5b858900413D35BFb7cb6b3B0d65b"
+      }
+    }
+  ]
+}

--- a/registry/livepeer/testsv2/calldata-BondingManager.tests.json
+++ b/registry/livepeer/testsv2/calldata-BondingManager.tests.json
@@ -143,7 +143,8 @@
             "label": "Unbonding lock",
             "value": "436"
           }
-        ]
+        ],
+        "interpolatedIntent": "Withdraw #436"
       }
     },
     {


### PR DESCRIPTION
Adds a calldata descriptor for Livepeer's BondingManager on Arbitrum One, the contract that holds orchestrator and delegator stake and pays inflationary rewards.

Nine functions: `setRewardCaller`, `reward`, `rewardWithHint`, `rewardForTranscoder`, `rewardForTranscoderWithHint`, `bondWithHint`, `unbondWithHint`, `withdrawFees`, `withdrawStake`.

Test vectors are ten real Arbitrum One transactions dated 2 to 4 September 2026, not synthetic calldata. Five are the LIP-118 rollout runs, taken from their published transaction hashes. The other five were found by querying `eth_getLogs` on BondingManager for `Bond`, `Unbond`, `Reward`, `WithdrawFees` and `WithdrawStake`, one vector from each, then fetching the transaction by hash.

I am not an official member of the Livepeer project. Happy to have a Livepeer protocol maintainer added as a reviewer.

### Why this contract

LIP-118 added delegated reward calling so an orchestrator's stake-holding key can stay cold while a separate low-value key calls `reward()`. That moves the stake key onto hardware wallets, where every transaction it signs is reviewed on a device screen.

This is that review today, with no descriptor. The command signs `setRewardCaller(0x41b8...232d)` against BondingManager on a Trezor Model T running the current firmware, 2.12.4:

```
trezorctl ethereum sign-tx \
  -n "m/44'/60'/0'/0/0" \
  -c 31337 -i 0 -g 100000 -G 100000000 \
  -d 0x0103e60e00000000000000000000000041b8c9fec44eeffd0cb8f3eaac242824e894232d \
  0x35Bcf3c30594191d53231E4FF333E8A770453e40 0

Please enter passphrase on your Trezor device.
Please confirm action on your Trezor device.
Signed raw transaction:
0xf8...
```

<img width="2600" height="902" alt="trezor-setrewardcaller-no-descriptor" src="https://github.com/user-attachments/assets/2ed61f78-0b2d-4092-9f84-d7506cb85007" />

The calldata in `-d` is what panels 1 and 2 show, paged as raw hex with CONFIRM ALL offered before the second page; the contract in panel 3 is disclosed only after the data is approved. The 20-byte address being granted reward authority is split across the page break, 22 hex characters before it and 18 after. The function name appears nowhere.

With this descriptor the same call renders as the fixture's first case: "Set or revoke reward caller", with "Reward caller" showing 0x1B0c26FC2E310eFB2649C24eC9AA966efFDA292F. The other eight functions get the same treatment: `bondWithHint` shows the LPT amount and the delegate, `withdrawFees` the ETH amount and recipient, and the list-position hints are hidden because they carry no value or authority, see "Hidden fields" below.

Chain id 31337 was used so the signature cannot land on Arbitrum One. That is why the summary panel reads UNKN rather than ETH, and why this is a legacy-type transaction where the fixture's mainnet vectors are all type 2. Neither changes the three data panels.

### The lint warnings, and why they are not stale selectors

`erc7730 lint` reports nine "Unknown selector" warnings and one "Missing display format: setController(address)". Both have the same cause, and neither means the descriptor targets the wrong contract.

Livepeer's managers sit behind `ManagerProxy`, which keeps no implementation pointer in a namespaced slot. Slot 0 is the Controller, slot 1 is the target's registry key, and the fallback delegates to `controller.getContract(targetContractId)`. Explorers therefore return the proxy's own three-function ABI, `controller()`, `setController(address)` and `targetContractId()`, and that is what the linter compares against.

The implementation resolves on chain:

```
cast call 0x35Bcf3c30594191d53231E4FF333E8A770453e40 'controller()(address)'
# 0xD8E8328501E9645d16Cf49539efC04f734606ee4

cast call 0x35Bcf3c30594191d53231E4FF333E8A770453e40 'targetContractId()(bytes32)'
# 0xfc6f6f33d2bb065ac61cbdd4dbe4b7adf6f3e7e6c6a3d1fe297cbf9a187092e4
#   == cast keccak 'BondingManagerTarget'

cast call 0xD8E8328501E9645d16Cf49539efC04f734606ee4 \
  'getContract(bytes32)(address)' \
  0xfc6f6f33d2bb065ac61cbdd4dbe4b7adf6f3e7e6c6a3d1fe297cbf9a187092e4
# 0xbe197fcBfe74DE8F10460EA61644B006cC0f0Bd2
```

Every selector in this descriptor exists in that implementation's verified ABI. The descriptor is bound to the proxy address because that is what transactions target and what the spec's proxy guidance calls for.

I tried clearing the warnings by attaching the implementation ABI inline as `context.contract.abi`. The schema accepts it, but lint output is byte-identical with and without it, so the linter always compares against explorer data. The spec marks that field deprecated, so I have left it out rather than ship a deprecated field that changes nothing.

Resolver support for this proxy pattern is merged upstream in shazow/whatsabi#216 and argotorg/sourcify#2959. Sourcify staging already answers `proxyType: LivepeerManagerProxy` with the implementation resolved; production is awaiting its next deploy.

`setController` has no display format on purpose. It is `onlyController` gated in `contracts/Manager.sol`, so it is not something a stake holder signs.

### Hidden fields

Ten fields are marked `visible: "never"`, six distinct parameter names, and every one is a sorted-list position hint. `_newPosPrev` and `_newPosNext` on `rewardWithHint`, `rewardForTranscoderWithHint` and `unbondWithHint`; `_oldDelegateNewPosPrev`, `_oldDelegateNewPosNext`, `_currDelegateNewPosPrev` and `_currDelegateNewPosNext` on `bondWithHint`.

These are hints into the sorted transcoder pool that let the contract skip an on-chain search. They carry no value and no authority, and a wrong hint costs gas rather than funds. Every value-bearing parameter, amounts, recipients, delegates and the reward caller address, is visible.

### What revoking looks like

LIP-118 revokes a delegation by calling `setRewardCaller(address(0))`, so the fixture's "Unset reward caller" case renders with a value of forty zeros. ERC-7730 has no conditional formatting for an address, so the same intent covers granting and revoking. The intent is therefore "Set or revoke reward caller", which spends the one string on that screen telling the operator that a zero address means revoke.

### Scope and follow-ups

This covers the LIP-118 reward-delegation flows, the main staking entry point and the exit path. `rebondWithHint`, `transcoderWithHint` and the un-hinted variants are the obvious next additions. The un-hinted ones are lower priority because the Livepeer Explorer sends the hint variants, so they see little real use. I would rather add each with a real mainnet vector than synthesise calldata.
