### PR TITLE
fix(tools): normalise index paths to forward slashes

### DIFF
--- a/tools/scripts/generate-index.js
+++ b/tools/scripts/generate-index.js
@@ -38,8 +38,14 @@ const EIP712_INDEX = 'index.eip712.json';
  */
 const EXCLUDED_DIRS = new Set(['tests', 'testsv2', 'sigs']);
 
+/** Repo-relative path with forward slashes. */
+function rel(absPath) {
+  return path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+}
+
 /**
- * Collects descriptor paths under registry/, repo-relative and sorted.
+ * Collects descriptor paths under registry/, repo-relative with forward
+ * slashes, and sorted.
  *
  * Only calldata-*.json / eip712-*.json files are descriptors. Shared files
  * pulled in via "includes" (common-*.json, *-common-*.json) do not match the
@@ -58,7 +64,7 @@ function findDescriptors(dir, found = []) {
       /^(calldata|eip712)-.*\.json$/.test(entry.name) &&
       !entry.name.endsWith('.tests.json')
     ) {
-      found.push(path.relative(REPO_ROOT, abs));
+      found.push(rel(abs));
     }
   }
   return found.sort();


### PR DESCRIPTION
`tools/scripts/generate-index.js` collects descriptor paths with `path.relative` and writes them straight into `index.calldata.json` and `index.eip712.json`. On Windows `path.relative` returns backslash-separated paths, so running the documented command rewrites every path in both files:

```diff
- "path": "registry/lens/eip712-lens-lenshub.json"
+ "path": "registry\lens\eip712-lens-lenshub.json"
```

```
$ npm run generate-index      # on Windows, before this change
Wrote index.calldata.json (909 entries)
Wrote index.eip712.json (185 entries)

backslash paths: 909 in index.calldata.json, 602 in index.eip712.json
```

1511 paths on the current tree.

## Why it matters

The script's own header says it best:

> They are published at the repo root and fetched directly by downstream libraries, so a stale index silently breaks clear signing for the affected contracts.

A path a consumer cannot resolve does exactly that, and nothing in CI catches it: `--validate` builds the indexes in memory and returns before comparing anything, which is correct for pull requests but means the corruption only shows up downstream.

## The fix

The repo already solved this. Both scripts under `.github/scripts` define:

```js
/** Repo-relative path with forward slashes. */
function rel(absPath) {
  return path.relative(repoRoot, absPath).split(path.sep).join('/');
}
```

`check-selector-coverage.js:34` and `list-affected-descriptors.js:68` both use it. `generate-index.js` is the one path-producing script that does not — so this adds the same helper, with the same doc comment, and uses it at the single call site that reaches the index files.

## Verification

Running the generator on Windows, before and after:

| | backslash paths in `index.calldata.json` | in `index.eip712.json` |
|---|---|---|
| before | 909 | 602 |
| **after** | **0** | **0** |

`node tools/scripts/generate-index.js --validate` still reports `Index is buildable (909 calldata, 185 eip712 entries)`.

## Two things I checked and deliberately left alone

**The committed index is currently behind the registry** — regenerating adds 214 lines for Lido L2, Ekubo, Zama and Porto entries, with no deletions. That is the expected pre-merge state described in the header, and `sync-indexes.yml` regenerates on master, so this PR does not touch the index files. I mention it only because it is the other half of what `--check` reports on a fresh clone, and I did not want the two effects confused.

**Other `path.relative` call sites** in `tools/scripts/` (`batch-process.js`, `migrate-v1-to-v2.js`, `check-contract-functions.js`) feed console output and non-committed reports rather than published artifacts, so they are cosmetic on Windows and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)