### PR TITLE
fix(lombard): render the network fee in LBTC, not ETH

### DIFF
--- a/registry/lombard/eip712-network-fee-authorization-mainnet.json
+++ b/registry/lombard/eip712-network-fee-authorization-mainnet.json
@@ -13,7 +13,7 @@
         "intent": "Lombard Network Fee Authorization",
         "fields": [
           { "path": "chainId", "label": "Chain ID", "format": "raw" },
-          { "path": "fee", "label": "Network Fee", "format": "amount" },
+          { "path": "fee", "label": "Max Network Fee", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
           { "path": "expiry", "label": "Expiry", "format": "date", "params": { "encoding": "timestamp" } }
         ]
       }

--- a/registry/lombard/eip712-network-fee-authorization-sepolia.json
+++ b/registry/lombard/eip712-network-fee-authorization-sepolia.json
@@ -13,7 +13,7 @@
         "intent": "Lombard Network Fee Authorization",
         "fields": [
           { "path": "chainId", "label": "Chain ID", "format": "raw" },
-          { "path": "fee", "label": "Network Fee", "format": "raw" },
+          { "path": "fee", "label": "Max Network Fee", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
           { "path": "expiry", "label": "Expiry", "format": "date", "params": { "encoding": "timestamp" } }
         ]
       }

--- a/registry/lombard/testsv2/eip712-network-fee-authorization-mainnet.tests.json
+++ b/registry/lombard/testsv2/eip712-network-fee-authorization-mainnet.tests.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../specs/erc7730-tests-v2.schema.json",
   "descriptor": "../eip712-network-fee-authorization-mainnet.json",
+  "dataProvider": { "tokens": { "0x8236a87084f8b84306f72007f36f2618a5634494": { "symbol": "LBTC", "decimals": 8, "name": "Lombard Staked Bitcoin" } } },
   "tests": [
     {
       "description": "Lombard Network Fee Authorization",
@@ -28,7 +29,7 @@
         "owner": "Lombard Finance",
         "fields": [
           { "label": "Chain ID", "value": "1" },
-          { "label": "Network Fee", "value": "0.0003 ETH" },
+          { "label": "Max Network Fee", "value": "3000000 LBTC" },
           { "label": "Expiry", "value": "2026-05-21 00:00:00Z" }
         ]
       }

--- a/registry/lombard/testsv2/eip712-network-fee-authorization-sepolia.tests.json
+++ b/registry/lombard/testsv2/eip712-network-fee-authorization-sepolia.tests.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../specs/erc7730-tests-v2.schema.json",
   "descriptor": "../eip712-network-fee-authorization-sepolia.json",
+  "dataProvider": { "tokens": { "0x731efa688f3679688cf60a3993b8658138953ed6": { "symbol": "LBTC", "decimals": 8, "name": "Lombard Staked Bitcoin" } } },
   "tests": [
     {
       "description": "Lombard Network Fee Authorization",
@@ -28,7 +29,7 @@
         "owner": "Lombard Finance",
         "fields": [
           { "label": "Chain ID", "value": "11155111" },
-          { "label": "Network Fee", "value": "2000000000000000" },
+          { "label": "Max Network Fee", "value": "20000000 LBTC" },
           { "label": "Expiry", "value": "2026-06-25 00:00:00Z" }
         ]
       }


### PR DESCRIPTION
Closes #2647 (High) and #2649 (Medium) — the same defect on the two `feeApproval` descriptors.

## The problem

`feeApproval(uint256 chainId, uint256 fee, uint256 expiry)` has exactly one value-bearing field, and neither descriptor rendered it as LBTC:

| | format | rendered | for a fee of |
|---|---|---|---|
| mainnet | `amount` | **`0.0003 ETH`** | `300000000000000` |
| sepolia | `raw` | **`2000000000000000`** | `2000000000000000` |

LBTC has **8 decimals**. So the mainnet screen displayed a **3,000,000 LBTC** ceiling as ETH dust ten orders of magnitude too small — any fee a dApp requested read as free, including a malicious one. The sepolia screen gave the signer no unit at all to reason about.

## The fix

Both fields now use `tokenAmount` against the verifying contract, which **is** the LBTC token on each chain. Verified on-chain rather than assumed:

```
eip155:1        0x8236a87084f8B84306f72007F36F2618A5634494  symbol LBTC  decimals 8
eip155:11155111 0x731eFa688F3679688cf60A3993b8658138953ED6  symbol LBTC  decimals 8
```

The label becomes `Max Network Fee`, since the value is a ceiling rather than the fee actually charged.

## On `params.tokenPath: "@.to"`

Both issues suggest it, and `@.to` reads like a calldata concept, so I checked before using it in an EIP-712 descriptor. `registry/circle/eip712-TransferWithAuthorization.json` uses exactly the same reference and its fixtures render `0.01 USDC` off a verifying contract that is the USDC token — so `@.to` resolves to the verifying contract here. The suggestion is correct.

## Fixtures

```
mainnet: 300000000000000  / 10^8 -> 3000000 LBTC
sepolia: 2000000000000000 / 10^8 -> 20000000 LBTC
```

A `dataProvider` entry supplies LBTC's symbol and 8 decimals on each chain so the fixtures need no network access.

Worth noting: the **legacy** mainnet fixture already expected `3000000 LBTC`. This restores a rendering that regressed at some point rather than inventing a new one — which is also why I am confident about the scale.

## Left alone

Both descriptors carry two pre-existing lint warnings that this PR does not touch: the intent `Lombard Network Fee Authorization` is 33 characters (limit 30) and the info URL is 28 (limit 26). Both would truncate on a Ledger. Not part of these findings and the intent wording looks deliberate, so I left them — happy to shorten in a follow-up if you would like.

`registry/lombard/calldata-lbtc-*.json` also have untested functions under the new `check-test-coverage` job, but this PR does not modify them so they are not affected.

## Validation

```
erc7730 lint ...-mainnet.json  -> 0 errors
erc7730 lint ...-sepolia.json  -> 0 errors
```

All four files validate against `specs/erc7730-v2.schema.json` and `specs/erc7730-tests-v2.schema.json`. Six lines changed in total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)